### PR TITLE
feat(email): add new email templates

### DIFF
--- a/apps/app.py
+++ b/apps/app.py
@@ -15,25 +15,6 @@ load_dotenv()
 
 write_creds()
 
-# def user_is_authorized(user_info: dict):
-#     """Check if the user is authorized to access the app.
-
-#     Args:
-
-#         user_info (dict): The user information.
-
-#     Returns:
-
-#         bool: True if the user is authorized, False otherwise.
-#     """
-#     with open(here() / 'apps/users.txt') as f:
-#         valid_users = [line.strip("\n") for line in f.readlines()]
-
-#     print(user_info['login'] in valid_users)
-#     return user_info['login'] in valid_users
-
-
-# pn.config.authorize_callback = user_is_authorized
 
 scripture_choices = [Luke, John, Ephesians, James]
 

--- a/sgbs_training/email.py
+++ b/sgbs_training/email.py
@@ -40,3 +40,46 @@ def compose_homework_email(scripture: str, questions_doc: dict, notes_doc: dict)
 林意 和 Eric
     """
     return text
+
+
+def compose_book_reflection_email():
+    text = """
+感謝你們參加小組查經帶領訓練主日學。如你們所知，我們有一項嚴格的出席政策，以此來認定訓練是否完成。
+通常情況下，需要參加5次會議中的4次。據我的記錄，諸位只出席3次。
+本季我和林意正在試驗一個備選方案：如果出席三次的話，就請對以下兩本書中的任一本進行書籍反思：
+
+- 《你們給他們吃吧！》
+    - [Apple Books](https://books.apple.com/us/book/%E4%BD%A0%E5%80%91%E7%B5%A6%E4%BB%96%E5%80%91%E5%90%83%E5%90%A7/id772422884)
+    - [AFC書店](https://afcresources.org/contents/en-us/p3719_Feed_Them.html)
+- Laurie Polich，《Help! I'm a Small-Group Leader!: 50 Ways to Lead Teenagers into Animated and Purposeful Discussions》，Zondervan，1998
+    - [亞馬遜](https://www.amazon.com/Help-Small-Group-Leader-Laurie-Polich/dp/0310224632/)
+    - [Apple Books](https://books.apple.com/cl/book/help-im-a-small-group-leader/id398995929)
+
+為了減輕購買書籍的財務負擔，如果你們需要的話，請將你的收據發給我，我很樂意負責coordinate報銷書籍費用。
+
+鑑於這是一次實驗，並且認識到我們各自的生活都挺忙的，我們原本考慮的deadline是2023年11月5日，
+但我認為更合適的deadline應該是課後一個月，即2023年12月3日。期待這樣會給你們更多時間去思考書裡的內容。
+
+如果你們覺得完成這項任務過於繁重，或者如果你們錯過了截止日期，歡迎你們春季學期再次加入我們。
+（你們的出席次數將在新的一季重置。）我也會向大家發送一個日曆邀請，並附上適時的提醒。
+
+如果有任何問題，請隨時發給我！
+"""
+    return text
+
+
+def compose_reinvitation_email():
+    text = """
+感謝你參加小組查經帶領訓練主日學。如你所知，我們有較嚴格的出席政策
+（[出席政策](https://cbcgb-com.github.io/sgbs-training/completion-policy/)）
+來確認是否完成訓練。
+我們的基本要求是5次課中至少要（a）出席三次加書本讀後感想，或者（b）出席四次，
+但根據我的記錄，你已經缺席了5次中的3次。因此，我們無法認定你完成了本次課程。
+（如果有誤，請務必跟我說！）
+
+這完全沒問題，我理解生活中會有各種事情發生。
+
+如果你想參加春季的主日學課程，我們非常歡迎你回來。
+（每季的出席次數會重置，所以下一季仍需滿足出席標準才算完成。）
+"""
+    return text


### PR DESCRIPTION
This PR introduces three new email templates to the sgbs_training module. These templates are designed to handle different scenarios in the training process:
    
1. `compose_book_reflection_email`: This template is used when a trainee has attended only three out of five meetings. It provides an alternative way to complete the training by reflecting on a book.
2. `compose_reinvitation_email`: This template is used when a trainee has missed three out of five meetings. It invites the trainee to join the training again in the next season.
3. `compose_homework_email`: This template is used to compose homework emails.

These changes aim to improve the communication process in the training program.