### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.8.1
@@ -17,7 +17,7 @@ jobs:
 
       # Taken from: https://github.com/drivendataorg/cloudpathlib/blob/master/.github/workflows/docs-preview.yml
       - name: Deploy site preview to Netlify
-        uses: nwtgck/actions-netlify@v1.1
+        uses: nwtgck/actions-netlify@v3.0.0
         with:
           publish-dir: "./site"
           production-deploy: false

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
   build-website:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
 
       - name: Install pixi
         uses: prefix-dev/setup-pixi@v0.8.1

--- a/.github/workflows/dokku-deploy.yaml
+++ b/.github/workflows/dokku-deploy.yaml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cloning repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@master
+        uses: dokku/github-action@v1.6.0
         with:
           branch: 'main'
           git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE_URL}}

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -13,7 +13,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v1
+      - uses: gr2m/merge-schedule-action@v2.4.3
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.

--- a/.github/workflows/version-updater.yaml
+++ b/.github/workflows/version-updater.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.7
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action)** published a new release **[v2.4.3](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.4.3)** on 2024-01-28T17:26:56Z
* **[nwtgck/actions-netlify](https://github.com/nwtgck/actions-netlify)** published a new release **[v3.0.0](https://github.com/nwtgck/actions-netlify/releases/tag/v3.0.0)** on 2024-03-10T02:11:38Z
* **[dokku/github-action](https://github.com/dokku/github-action)** published a new release **[v1.6.0](https://github.com/dokku/github-action/releases/tag/v1.6.0)** on 2024-09-14T05:27:25Z
