### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/dokku-deploy.yaml
+++ b/.github/workflows/dokku-deploy.yaml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Push to dokku
-        uses: dokku/github-action@v1.6.0
+        uses: dokku/github-action@v1.6.1
         with:
           branch: 'main'
           git_remote_url: ${{ secrets.DOKKU_GIT_REMOTE_URL}}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[dokku/github-action](https://github.com/dokku/github-action)** published a new release **[v1.6.1](https://github.com/dokku/github-action/releases/tag/v1.6.1)** on 2024-09-29T05:59:11Z
