### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.8.2
 
       - name: Setup environment and build website
         run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.1
+        uses: prefix-dev/setup-pixi@v0.8.2
 
 
       - name: Setup environment and build website

--- a/.github/workflows/merge-schedule.yaml
+++ b/.github/workflows/merge-schedule.yaml
@@ -13,7 +13,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v2.5.0
+      - uses: gr2m/merge-schedule-action@v2.6.0
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi)** published a new release **[v0.8.2](https://github.com/prefix-dev/setup-pixi/releases/tag/v0.8.2)** on 2025-02-11T15:59:56Z
* **[gr2m/merge-schedule-action](https://github.com/gr2m/merge-schedule-action)** published a new release **[v2.6.0](https://github.com/gr2m/merge-schedule-action/releases/tag/v2.6.0)** on 2025-02-13T17:16:57Z
