### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5.4.2
+        uses: astral-sh/setup-uv@v6.0.0
         with:
           version: "latest"
 


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.0.0](https://github.com/astral-sh/setup-uv/releases/tag/v6.0.0)** on 2025-04-24T14:07:47Z
