### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.9
+        uses: prefix-dev/setup-pixi@v0.8.10
 
       - name: Setup environment and build website
         run: |

--- a/.github/workflows/deploy-app.yaml
+++ b/.github/workflows/deploy-app.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4.2.2
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6.3.0
+        uses: astral-sh/setup-uv@v6.3.1
         with:
           version: "latest"
 

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
 
       - name: Install pixi
-        uses: prefix-dev/setup-pixi@v0.8.9
+        uses: prefix-dev/setup-pixi@v0.8.10
 
 
       - name: Setup environment and build website


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[prefix-dev/setup-pixi](https://github.com/prefix-dev/setup-pixi)** published a new release **[v0.8.10](https://github.com/prefix-dev/setup-pixi/releases/tag/v0.8.10)** on 2025-06-22T15:59:05Z
* **[astral-sh/setup-uv](https://github.com/astral-sh/setup-uv)** published a new release **[v6.3.1](https://github.com/astral-sh/setup-uv/releases/tag/v6.3.1)** on 2025-06-25T07:33:42Z
