### PR TITLE
feat(socratic): Socratic coach experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ cbcgb-com-sgbs-training-*.json
 
 # SQLite database
 message_log.db
+.envrc

--- a/apps/observation/__init__.py
+++ b/apps/observation/__init__.py
@@ -1,0 +1,1 @@
+"""Guided Scripture Observation app — who/when/where highlighting and annotations."""

--- a/apps/observation/app.py
+++ b/apps/observation/app.py
@@ -1,0 +1,79 @@
+"""FastAPI app for Guided Scripture Observation — who/when/where + annotations."""
+
+import json
+import traceback
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse, PlainTextResponse
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import JSONResponse
+
+from .entities import build_verse_segments
+from .llm import generate_explanation_questions, generate_major_events
+from .passages import PASSAGE, get_passage_verses
+
+app = FastAPI(
+    title="Guided Scripture Observation",
+    description="Observation-phase UI: who/when/where highlighting and annotations for inductive Bible study.",
+)
+_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+
+@app.get("/api/events")
+def api_events():
+    """Return 3–5 major events for the current passage (AI-generated via Groq)."""
+    verses = get_passage_verses(PASSAGE)
+    passage_text = "\n".join(f'{v["n"]} {v["text"]}' for v in verses)
+    reference = PASSAGE.get("reference_zh", "") + " / " + PASSAGE.get("reference_en", "")
+    events = generate_major_events(passage_text, reference)
+    return JSONResponse(content=events)
+
+
+@app.get("/api/explanation-questions")
+def api_explanation_questions():
+    """Return 3–6 suggested explanation questions for the current passage (AI-generated via Groq)."""
+    verses = get_passage_verses(PASSAGE)
+    passage_text = "\n".join(f'{v["n"]} {v["text"]}' for v in verses)
+    reference = PASSAGE.get("reference_zh", "") + " / " + PASSAGE.get("reference_en", "")
+    questions = generate_explanation_questions(passage_text, reference)
+    return JSONResponse(content=questions)
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    """Observation UI: scripture left (simplified), who/when/where toggles + observations right."""
+    try:
+        verses = get_passage_verses(PASSAGE)
+        verse_segments_list = build_verse_segments(PASSAGE)
+        # Pair verse number with segments for template
+        verse_rows = [
+            {"verse_n": v["n"], "segments": verse_segments_list[i]}
+            for i, v in enumerate(verses)
+        ]
+        passage_ref = "luke_7_36_50"  # for localStorage key
+        # Event cards are loaded client-side from /api/events (AI-generated 3–5 major events)
+        event_cards_json = json.dumps([], ensure_ascii=False)
+        # Render template to string so any Jinja2 error is caught here
+        template = templates.env.get_template("index.html")
+        html_str = template.render(
+            request=request,
+            passage=PASSAGE,
+            verse_rows=verse_rows,
+            passage_ref=passage_ref,
+            event_cards_json=event_cards_json,
+        )
+        return HTMLResponse(html_str)
+    except Exception:
+        return PlainTextResponse(
+            traceback.format_exc(),
+            status_code=500,
+            media_type="text/plain; charset=utf-8",
+        )
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=5008)

--- a/apps/observation/entities.py
+++ b/apps/observation/entities.py
@@ -1,0 +1,146 @@
+"""Who / when / where entity definitions for observation-phase highlighting."""
+
+from typing import Literal
+
+from .passages import get_passage_verses
+
+EntityType = Literal["who", "when", "where"]
+
+
+def _find_entity_offsets(
+    passage: dict,
+) -> list[tuple[int, int, int, EntityType, str]]:
+    """Return list of (verse_n, start, end, type, label). start/end in verse text."""
+    verses_list = get_passage_verses(passage)
+    verse_by_n = {v["n"]: v["text"] for v in verses_list}
+
+    raw: list[tuple[int, str, EntityType, str]] = [
+        (36, "法利赛人", "who", "法利赛人"),
+        (36, "耶稣", "who", "耶稣"),
+        (37, "女人", "who", "女人"),
+        (37, "罪人", "who", "罪人"),
+        (37, "耶稣", "who", "耶稣"),
+        (38, "耶稣", "who", "耶稣"),
+        (39, "法利赛人", "who", "法利赛人"),
+        (39, "女人", "who", "女人"),
+        (39, "罪人", "who", "罪人"),
+        (40, "耶稣", "who", "耶稣"),
+        (40, "西门", "who", "西门"),
+        (41, "耶稣", "who", "耶稣"),
+        (41, "债主", "who", "债主"),
+        (41, "两个人", "who", "两个人"),
+        (42, "债主", "who", "债主"),
+        (42, "两个人", "who", "两个人"),
+        (42, "这两个人", "who", "这两个人"),
+        (43, "西门", "who", "西门"),
+        (43, "耶稣", "who", "耶稣"),
+        (44, "女人", "who", "女人"),
+        (44, "西门", "who", "西门"),
+        (45, "女人", "who", "女人"),
+        (46, "女人", "who", "女人"),
+        (48, "女人", "who", "女人"),
+        (49, "同席的人", "who", "同席的人"),
+        (50, "耶稣", "who", "耶稣"),
+        (50, "女人", "who", "女人"),
+        (36, "吃饭", "when", "吃饭"),
+        (36, "坐席", "when", "坐席"),
+        (37, "坐席", "when", "坐席"),
+        (45, "进来的时候", "when", "进来的时候"),
+        (36, "法利赛人家里", "where", "法利赛人家里"),
+        (37, "城里", "where", "城里"),
+        (37, "法利赛人家里", "where", "法利赛人家里"),
+        (44, "你的家", "where", "你的家"),
+    ]
+
+    out: list[tuple[int, int, int, EntityType, str]] = []
+    for verse_n, phrase, etype, label in raw:
+        text = verse_by_n.get(verse_n)
+        if not text or phrase not in text:
+            continue
+        start = text.index(phrase)
+        end = start + len(phrase)
+        out.append((verse_n, start, end, etype, label))
+
+    return _dedupe_overlapping(out)
+
+
+def _dedupe_overlapping(
+    entities: list[tuple[int, int, int, EntityType, str]],
+) -> list[tuple[int, int, int, EntityType, str]]:
+    """Per verse, keep non-overlapping spans (first occurrence wins)."""
+    by_verse: dict[int, list[tuple[int, int, EntityType, str]]] = {}
+    for verse_n, start, end, etype, label in entities:
+        by_verse.setdefault(verse_n, []).append((start, end, etype, label))
+
+    result: list[tuple[int, int, int, EntityType, str]] = []
+    for verse_n in sorted(by_verse.keys()):
+        spans = sorted(by_verse[verse_n], key=lambda x: x[0])
+        last_end = -1
+        for start, end, etype, label in spans:
+            if start >= last_end:
+                result.append((verse_n, start, end, etype, label))
+                last_end = end
+    return result
+
+
+def get_entities_for_passage(passage: dict) -> list[dict]:
+    """Return entities: verse_n, start, end, type, label, entity_id (stable)."""
+    raw = _find_entity_offsets(passage)
+    type_index: dict[tuple[int, EntityType], int] = {}
+    out = []
+    for verse_n, start, end, etype, label in raw:
+        key = (verse_n, etype)
+        type_index[key] = type_index.get(key, 0) + 1
+        entity_id = f"v{verse_n}_{etype}_{type_index[key]}"
+        out.append({
+            "verse_n": verse_n,
+            "start": start,
+            "end": end,
+            "type": etype,
+            "label": label,
+            "entity_id": entity_id,
+        })
+    return out
+
+
+def build_verse_segments(passage: dict) -> list[list[dict]]:
+    """Build segments per verse for template: list of verse segment lists.
+    Segment = {"kind": "text", "content": "..."} or
+              {"kind": "entity", "content": "...", "entity_id", "entity_type", "entity_label"}.
+    """
+    verses = get_passage_verses(passage)
+    entities = get_entities_for_passage(passage)
+    by_verse: dict[int, list[dict]] = {e["verse_n"]: [] for e in entities}
+    for e in entities:
+        by_verse[e["verse_n"]].append(e)
+    for v in verses:
+        by_verse.setdefault(v["n"], [])
+    for verse_n in by_verse:
+        by_verse[verse_n].sort(key=lambda x: x["start"])
+
+    result: list[list[dict]] = []
+    for v in verses:
+        verse_n = v["n"]
+        text = v["text"]
+        ents = by_verse.get(verse_n) or []
+        segments: list[dict] = []
+        if not ents:
+            segments.append({"kind": "text", "content": text})
+            result.append(segments)
+            continue
+        pos = 0
+        for e in ents:
+            if e["start"] > pos:
+                segments.append({"kind": "text", "content": text[pos : e["start"]]})
+            segments.append({
+                "kind": "entity",
+                "content": text[e["start"] : e["end"]],
+                "entity_id": e["entity_id"],
+                "entity_type": e["type"],
+                "entity_label": e["label"],
+            })
+            pos = e["end"]
+        if pos < len(text):
+            segments.append({"kind": "text", "content": text[pos:]})
+        result.append(segments)
+    return result

--- a/apps/observation/events.py
+++ b/apps/observation/events.py
@@ -1,0 +1,25 @@
+"""Event cards for "what" / sequence of events (Luke 7:36-50)."""
+
+# Default order: summary of events without quoting scripture
+LUKE_7_36_50_EVENTS = [
+    {"id": "e1", "label": "法利赛人请耶稣吃饭，耶稣到他家里坐席"},
+    {"id": "e2", "label": "一个女人（罪人）拿香膏来到耶稣脚前"},
+    {"id": "e3", "label": "女人哭，用眼泪湿耶稣的脚，用头发擦乾，亲脚，抹香膏"},
+    {"id": "e4", "label": "请耶稣的法利赛人心里说：这人若是先知，必知道摸他的是谁"},
+    {"id": "e5", "label": "耶稣对西门说：我有句话要对你说"},
+    {"id": "e6", "label": "耶稣讲比喻：债主免了两个欠债人的债，谁更爱他？"},
+    {"id": "e7", "label": "西门回答：是那多得恩免的人。耶稣说：你断的不错"},
+    {"id": "e8", "label": "耶稣转向女人，对西门对比：你没给我洗脚、亲嘴、抹油，这女人都做了"},
+    {"id": "e9", "label": "耶稣说：她许多的罪都赦免了，因为她的爱多"},
+    {"id": "e10", "label": "耶稣对女人说：你的罪赦免了"},
+    {"id": "e11", "label": "同席的人心里说：这是甚麽人，竟赦免人的罪呢？"},
+    {"id": "e12", "label": "耶稣对女人说：你的信救了你，平平安安回去吧"},
+]
+
+
+def get_events_for_passage(passage: dict) -> list[dict]:
+    """Return default event cards for the passage (Luke 7:36-50 only)."""
+    ref = passage.get("reference_en", "")
+    if "Luke 7:36" in ref or "7:36" in ref:
+        return LUKE_7_36_50_EVENTS
+    return []

--- a/apps/observation/llm.py
+++ b/apps/observation/llm.py
@@ -1,0 +1,132 @@
+"""Generate 3–5 major events and explanation questions from passage text via Groq (structured output)."""
+
+import json
+import os
+from typing import Any
+
+try:
+    from litellm import completion
+except ImportError:
+    completion = None  # type: ignore
+
+MODEL = "groq/openai/gpt-oss-120b"
+
+SYSTEM_PROMPT = """You are helping with inductive Bible study. Given a scripture passage in simplified Chinese, output exactly 3 to 5 major story events (何事) as a JSON object.
+
+Rules:
+- Output ONLY valid JSON, no other text.
+- Use this exact shape: {"events": [{"id": "e1", "label": "简短摘要"}, ...]}
+- ids: "e1", "e2", "e3", ... (one per event, 3–5 total).
+- label: one short sentence in simplified Chinese summarizing that major event. Do not quote the scripture; summarize in your own words.
+- Choose the 3–5 most important plot beats (setting, key actions, climax, resolution). Do not list every verse."""
+
+EXPLANATION_QUESTIONS_PROMPT = """You are helping with inductive Bible study. Given a scripture passage in simplified Chinese, output 3 to 6 explanation questions (解释性问题) as a JSON object. These questions help the group explain what is going on: motives (人物动机), cultural background (文化背景), and meaning (神学/经文意义).
+
+Rules:
+- Output ONLY valid JSON, no other text.
+- Use this exact shape: {"questions": [{"id": "eq1", "text": "问题内容"}, ...]}
+- ids: "eq1", "eq2", "eq3", ... (one per question, 3–6 total).
+- text: one question in simplified Chinese. Questions should:
+  - Be suitable for group discussion (not yes/no answers).
+  - Go from simpler to deeper. Ask about motives in concrete ways (e.g. "可能在想什么" rather than vague "为什么").
+  - Cover 为何 (why / motives) and 何意 (what does it mean). Include cultural background where relevant.
+- Do not quote long scripture; refer to characters or events briefly."""
+
+
+def _has_api_key() -> bool:
+    return bool(os.environ.get("GROQ_API_KEY"))
+
+
+def generate_major_events(passage_text: str, reference: str = "") -> list[dict[str, str]]:
+    """
+    Call Groq to get 3–5 major events from passage text.
+    Returns list of {"id": "e1", "label": "..."}; empty list on error or missing key.
+    """
+    if completion is None:
+        return []
+    if not _has_api_key():
+        return []
+
+    user_content = f"Scripture reference: {reference}\n\nPassage text (simplified Chinese):\n{passage_text}"
+
+    try:
+        response = completion(
+            model=MODEL,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            temperature=0.3,
+            response_format={"type": "json_object"},
+        )
+        raw = (response.choices[0].message.content or "").strip()
+        if not raw:
+            return []
+        # Strip markdown code fence if present
+        if raw.startswith("```"):
+            raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+        data: Any = json.loads(raw)
+        events = data.get("events")
+        if not isinstance(events, list):
+            return []
+        out = []
+        for i, item in enumerate(events[:10]):
+            if not isinstance(item, dict):
+                continue
+            eid = item.get("id") or f"e{i+1}"
+            if not isinstance(eid, str):
+                eid = f"e{i+1}"
+            label = item.get("label")
+            if not isinstance(label, str) or not label.strip():
+                continue
+            out.append({"id": eid.strip(), "label": label.strip()})
+        return out[:5]  # cap at 5
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError, Exception):
+        return []
+
+
+def generate_explanation_questions(passage_text: str, reference: str = "") -> list[dict[str, str]]:
+    """
+    Call Groq to get 3–6 explanation questions (解释性问题) for the passage.
+    Returns list of {"id": "eq1", "text": "..."}; empty list on error or missing key.
+    """
+    if completion is None:
+        return []
+    if not _has_api_key():
+        return []
+
+    user_content = f"Scripture reference: {reference}\n\nPassage text (simplified Chinese):\n{passage_text}"
+
+    try:
+        response = completion(
+            model=MODEL,
+            messages=[
+                {"role": "system", "content": EXPLANATION_QUESTIONS_PROMPT},
+                {"role": "user", "content": user_content},
+            ],
+            temperature=0.3,
+            response_format={"type": "json_object"},
+        )
+        raw = (response.choices[0].message.content or "").strip()
+        if not raw:
+            return []
+        if raw.startswith("```"):
+            raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
+        data: Any = json.loads(raw)
+        questions = data.get("questions")
+        if not isinstance(questions, list):
+            return []
+        out = []
+        for i, item in enumerate(questions[:10]):
+            if not isinstance(item, dict):
+                continue
+            eid = item.get("id") or f"eq{i+1}"
+            if not isinstance(eid, str):
+                eid = f"eq{i+1}"
+            text = item.get("text")
+            if not isinstance(text, str) or not text.strip():
+                continue
+            out.append({"id": eid.strip(), "text": text.strip()})
+        return out[:6]  # cap at 6
+    except (json.JSONDecodeError, KeyError, IndexError, TypeError, Exception):
+        return []

--- a/apps/observation/passages.py
+++ b/apps/observation/passages.py
@@ -1,0 +1,55 @@
+"""Passage text for observation app — Luke 7:36-50 simplified Chinese only."""
+
+import re
+from typing import TypedDict
+
+# Luke 7:36-50 — 耶穌在西門家 / Jesus at Simon the Pharisee's house
+# Source: CUV Simplified (Chinese Union Version)
+
+
+class Verse(TypedDict):
+    n: int
+    text: str
+
+
+def _split_chinese_verses(text: str) -> list[Verse]:
+    """Split Chinese passage (one verse per line, leading digit(s))."""
+    verses: list[Verse] = []
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        m = re.match(r"^(\d+)\s*(.*)$", line)
+        if m:
+            verses.append({"n": int(m.group(1)), "text": (m.group(2) or "").strip() or line})
+        else:
+            verses.append({"n": 0, "text": line})
+    return verses
+
+
+LUKE_7_36_50 = {
+    "reference_zh": "路加福音 7:36–50",
+    "reference_en": "Luke 7:36–50",
+    "simplified": """36 有一个法利赛人请耶稣和他吃饭；耶稣就到法利赛人家里去坐席。
+37 那城里有一个女人，是个罪人，知道耶稣在法利赛人家里坐席，就拿着盛香膏的玉瓶，
+38 站在耶稣背後，挨着他的脚哭，眼泪湿了耶稣的脚，就用自己的头发擦乾，又用嘴连连亲他的脚，把香膏抹上。
+39 请耶稣的法利赛人看见这事，心里说：这人若是先知，必知道摸他的是谁，是个怎样的女人，乃是个罪人。
+40 耶稣对他说：西门！我有句话要对你说。西门说：夫子，请说。
+41 耶稣说：一个债主有两个人欠他的债；一个欠五十两银子，一个欠五两银子；
+42 因为他们无力偿还，债主就开恩免了他们两个人的债。这两个人那一个更爱他呢？
+43 西门回答说：我想是那多得恩免的人。耶稣说：你断的不错。
+44 於是转过来向着那女人，便对西门说：你看见这女人麽？我进了你的家，你没有给我水洗脚；但这女人用眼泪湿了我的脚，用头发擦乾。
+45 你没有与我亲嘴；但这女人从我进来的时候就不住的用嘴亲我的脚。
+46 你没有用油抹我的头；但这女人用香膏抹我的脚。
+47 所以我告诉你，他许多的罪都赦免了，因为他的爱多；但那赦免少的，他的爱就少。
+48 於是对那女人说：你的罪赦免了。
+49 同席的人心里说：这是甚麽人，竟赦免人的罪呢？
+50 耶稣对那女人说：你的信救了你；平平安安的回去罢！""",
+}
+
+PASSAGE = LUKE_7_36_50
+
+
+def get_passage_verses(passage: dict) -> list[Verse]:
+    """Return passage as list of verses (simplified only)."""
+    return _split_chinese_verses(passage["simplified"])

--- a/apps/observation/templates/index.html
+++ b/apps/observation/templates/index.html
@@ -1,0 +1,893 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>观察阶段 — {{ passage.reference_zh }}</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .entity { cursor: pointer; border-radius: 2px; padding: 0 1px; }
+        .entity:hover { opacity: 0.9; }
+        .entity-who { background-color: rgba(147, 197, 253, 0.5); }
+        .entity-when { background-color: rgba(254, 215, 170, 0.7); }
+        .entity-where { background-color: rgba(167, 243, 208, 0.6); }
+        .passage-container.hide-who .entity-who { background: none; color: inherit; }
+        .passage-container.hide-when .entity-when { background: none; color: inherit; }
+        .passage-container.hide-where .entity-where { background: none; color: inherit; }
+        .passage-container.only-kept-highlights .entity:not(.entity-kept) { background: none; color: inherit; }
+        .obs-card-who { background-color: rgba(147, 197, 253, 0.25); border-color: rgba(147, 197, 253, 0.5); }
+        .obs-card-when { background-color: rgba(254, 215, 170, 0.4); border-color: rgba(251, 146, 60, 0.5); }
+        .obs-card-where { background-color: rgba(167, 243, 208, 0.35); border-color: rgba(52, 211, 153, 0.5); }
+        .popover { position: fixed; z-index: 50; background: white; border: 1px solid #e5e7eb; border-radius: 8px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); padding: 12px; min-width: 260px; }
+        .right-panel-view { display: none !important; flex-direction: column; height: 100%; min-height: 0; overflow: hidden; }
+        .right-panel-view.active { display: flex !important; }
+        .event-card { cursor: grab; user-select: none; }
+        .event-card:active { cursor: grabbing; }
+        .event-card.dragging { opacity: 0.5; }
+        .event-card.drag-over { background: rgba(59, 130, 246, 0.15); border-color: rgba(59, 130, 246, 0.5); }
+        .question-card { cursor: grab; user-select: none; }
+        .question-card:active { cursor: grabbing; }
+        .question-card.dragging { opacity: 0.5; }
+        .question-card.drag-over { background: rgba(59, 130, 246, 0.15); border-color: rgba(59, 130, 246, 0.5); }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-900 h-screen flex flex-col overflow-hidden">
+    <div class="flex flex-1 min-h-0">
+        <!-- Left: Scripture (simplified only) -->
+        <aside class="w-1/2 flex flex-col border-r border-gray-200 bg-white shrink-0">
+            <div class="px-4 py-3 border-b border-gray-200 shrink-0">
+                <h1 class="text-lg font-semibold">观察阶段</h1>
+                <p class="text-sm text-gray-600">{{ passage.reference_zh }} / {{ passage.reference_en }}</p>
+            </div>
+            <div id="passage-container" class="passage-container flex-1 overflow-auto p-4 text-gray-800 leading-relaxed">
+                {% for row in verse_rows %}
+                <div class="verse-block mb-2" data-verse="{{ row.verse_n }}">
+                    <span class="text-gray-500 font-medium mr-1">{{ row.verse_n }}</span>
+                    {% for seg in row.segments %}
+                    {% if seg.kind == "text" %}
+                    {{ seg.content }}
+                    {% else %}
+                    <span class="entity entity-{{ seg.entity_type }}" data-entity-id="{{ seg.entity_id }}" data-entity-type="{{ seg.entity_type }}" data-entity-label="{{ seg.entity_label }}">{{ seg.content }}</span>
+                    {% endif %}
+                    {% endfor %}
+                </div>
+                {% endfor %}
+            </div>
+        </aside>
+
+        <!-- Right: three panels — observation (step 1a), sequence (step 1b), explanation (step 2) -->
+        <main class="flex-1 flex flex-col min-w-0 min-h-0 bg-white overflow-hidden">
+            <div id="panel-observation" class="right-panel-view active">
+                <div class="px-4 py-3 border-b border-gray-200 shrink-0 flex items-center justify-between">
+                    <h2 class="text-base font-semibold text-gray-800">步骤 1：观察（谁 / 何时 / 何处）</h2>
+                    <button type="button" id="btn-next" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">下一步</button>
+                </div>
+                <div class="px-4 py-3 border-b border-gray-200 shrink-0">
+                    <p class="text-sm font-medium text-gray-700 mb-2">高亮类型</p>
+                    <div class="flex gap-2 flex-wrap">
+                        <button type="button" id="btn-who" class="toggle-btn px-3 py-1.5 rounded text-sm bg-blue-100 text-blue-800 border border-blue-200" data-type="who">谁 (Who)</button>
+                        <button type="button" id="btn-when" class="toggle-btn px-3 py-1.5 rounded text-sm bg-orange-100 text-orange-800 border border-orange-200" data-type="when">何时 (When)</button>
+                        <button type="button" id="btn-where" class="toggle-btn px-3 py-1.5 rounded text-sm bg-green-100 text-green-800 border border-green-200" data-type="where">何处 (Where)</button>
+                    </div>
+                </div>
+                <div class="flex-1 overflow-auto px-4 py-4">
+                    <h3 class="text-sm font-semibold text-gray-700 mb-2">我的观察</h3>
+                    <p class="text-xs text-gray-500 mb-2">点击经文中高亮词语可保留为观察并填写「为何重要」。</p>
+                    <ul id="observations-list" class="space-y-2"></ul>
+                </div>
+            </div>
+            <div id="panel-sequence" class="right-panel-view">
+                <div class="px-4 py-4 border-b border-gray-200 shrink-0 flex items-center justify-between bg-gray-50">
+                    <h2 class="text-base font-semibold text-gray-800">步骤 1：观察事件顺序（何事）</h2>
+                    <div class="flex gap-2">
+                        <button type="button" id="btn-sequence-back" class="px-3 py-1.5 text-sm bg-gray-200 text-gray-800 rounded hover:bg-gray-300">上一步</button>
+                        <button type="button" id="btn-sequence-next" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">下一步</button>
+                    </div>
+                </div>
+                <div class="px-4 py-3 shrink-0">
+                    <p class="text-sm text-gray-600">拖拽卡片排列故事发生的顺序。</p>
+                </div>
+                <ul id="sequence-list" class="flex-1 overflow-auto px-4 pb-4 space-y-2 min-h-0"></ul>
+            </div>
+            <div id="panel-explanation" class="right-panel-view">
+                <div class="px-4 py-3 border-b border-gray-200 shrink-0 flex items-center justify-between">
+                    <h2 class="text-base font-semibold text-gray-800">步骤 2：解释性问题（为何 / 何意）</h2>
+                    <button type="button" id="btn-explanation-back" class="px-3 py-1.5 text-sm bg-gray-200 text-gray-800 rounded hover:bg-gray-300">上一步</button>
+                </div>
+                <div class="flex-1 overflow-auto px-4 py-4 min-h-0 flex flex-col">
+                    <p class="text-sm text-gray-700 mb-1">这些问题帮助你思考经文的『为什么』和『什么意思』，从而更理解这段经文。</p>
+                    <p class="text-xs text-gray-500 mb-2">针对你保留的观察，写下能帮助你理解动机、背景与意义的问题。</p>
+                    <p id="explanation-kept-summary" class="text-xs text-gray-600 mb-2"></p>
+                    <details class="mb-3 text-sm text-gray-600">
+                        <summary class="cursor-pointer text-gray-500 hover:text-gray-700">示例问题</summary>
+                        <ul class="mt-2 space-y-1 list-disc list-inside">
+                            <li>西门心里可能怎样看待这位女人？经文没有明说，我们可以根据上下文一起推测。</li>
+                            <li>耶稣对女人说「你的罪赦了」想表达什么？</li>
+                        </ul>
+                    </details>
+                    <div id="explanation-empty" class="flex flex-col gap-3 py-4">
+                        <button type="button" id="btn-template-first" class="px-4 py-2 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 w-fit">用模板写第一个问题</button>
+                        <p class="text-xs text-gray-500">或</p>
+                        <button type="button" id="btn-generate-first" class="px-4 py-2 text-sm bg-gray-100 text-gray-800 border border-gray-300 rounded hover:bg-gray-200 w-fit">生成示例问题（可修改）</button>
+                        <p class="text-xs text-gray-500">参考示例的问法，写出能帮助你理解经文的问题。</p>
+                    </div>
+                    <div id="explanation-list-block" class="hidden flex-1 flex flex-col min-h-0">
+                        <h3 class="text-sm font-semibold text-gray-700 mb-2">我的解释性问题</h3>
+                        <p class="text-xs text-gray-500 mb-2">列出后可以逐题思考这些问题，帮助自己更理解经文。可以拖拽调整顺序，从简单到深入。</p>
+                        <ul id="explanation-list" class="space-y-2 flex-1 overflow-auto min-h-0"></ul>
+                        <div class="flex flex-wrap gap-2 mt-3 shrink-0">
+                            <button type="button" id="btn-template-add" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">用模板添加</button>
+                            <button type="button" id="btn-add-question" class="px-3 py-1.5 text-sm bg-gray-100 text-gray-800 border border-gray-300 rounded hover:bg-gray-200">添加问题</button>
+                            <button type="button" id="btn-generate-more" class="px-3 py-1.5 text-sm bg-gray-100 text-gray-800 border border-gray-300 rounded hover:bg-gray-200">生成示例问题（可修改）</button>
+                        </div>
+                    </div>
+                    <div id="explanation-template-form" class="hidden mt-3 p-3 border border-gray-200 rounded-lg bg-gray-50">
+                        <p class="text-sm font-medium text-gray-700 mb-2">用模板添加</p>
+                        <div class="mb-2">
+                            <span class="text-xs text-gray-600">问题类型：</span>
+                            <label class="ml-2"><input type="radio" name="expl-template-type" value="motive" /> 动机</label>
+                            <label class="ml-2"><input type="radio" name="expl-template-type" value="culture" /> 文化·背景</label>
+                            <label class="ml-2"><input type="radio" name="expl-template-type" value="meaning" /> 意义</label>
+                        </div>
+                        <div id="expl-template-target-wrap" class="mb-2">
+                            <label class="text-xs text-gray-600">针对谁？</label>
+                            <select id="expl-template-who" class="ml-2 border border-gray-300 rounded px-2 py-1 text-sm"></select>
+                        </div>
+                        <div id="expl-template-culture-wrap" class="mb-2 hidden">
+                            <label class="text-xs text-gray-600">针对哪件事/哪个观察？</label>
+                            <select id="expl-template-target" class="ml-2 border border-gray-300 rounded px-2 py-1 text-sm"></select>
+                        </div>
+                        <div class="mb-2">
+                            <label class="text-xs text-gray-600 block mb-1">问题（可编辑）：</label>
+                            <textarea id="expl-template-text" rows="2" class="w-full border border-gray-300 rounded px-2 py-1 text-sm"></textarea>
+                        </div>
+                        <div class="flex gap-2">
+                            <button type="button" id="expl-template-submit" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">添加</button>
+                            <button type="button" id="expl-template-cancel" class="px-3 py-1.5 text-sm bg-gray-200 text-gray-800 rounded hover:bg-gray-300">取消</button>
+                        </div>
+                    </div>
+                    <div id="explanation-freeform-form" class="hidden mt-3 p-3 border border-gray-200 rounded-lg bg-gray-50">
+                        <p class="text-sm font-medium text-gray-700 mb-2">添加问题</p>
+                        <textarea id="expl-freeform-text" rows="2" class="w-full border border-gray-300 rounded px-2 py-1 text-sm mb-2" placeholder="输入你的问题…"></textarea>
+                        <div class="flex gap-2">
+                            <button type="button" id="expl-freeform-submit" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">添加</button>
+                            <button type="button" id="expl-freeform-cancel" class="px-3 py-1.5 text-sm bg-gray-200 text-gray-800 rounded hover:bg-gray-300">取消</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script type="application/json" id="event-cards-json">{{ event_cards_json | safe }}</script>
+
+    <!-- Modal: merge or replace explanation questions after AI generate -->
+    <div id="explanation-merge-modal" class="popover hidden" aria-hidden="true" style="left:50%;top:50%;transform:translate(-50%,-50%);">
+        <p class="text-sm font-medium text-gray-700 mb-2">已生成示例问题，请选择：</p>
+        <label class="block mb-2"><input type="radio" name="expl-merge-mode" value="append" /> 加入列表 — 将示例问题追加到现有问题后</label>
+        <label class="block mb-3"><input type="radio" name="expl-merge-mode" value="replace" /> 替换当前列表 — 用示例问题替换全部</label>
+        <div class="flex gap-2">
+            <button type="button" id="expl-merge-confirm" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">确定</button>
+            <button type="button" id="expl-merge-cancel" class="px-3 py-1.5 text-sm bg-gray-200 text-gray-800 rounded hover:bg-gray-300">取消</button>
+        </div>
+    </div>
+
+    <!-- Popover for keep + annotate (hidden by default) -->
+    <div id="popover" class="popover hidden" aria-hidden="true">
+        <p id="popover-label" class="text-sm font-medium text-gray-700 mb-2"></p>
+        <label class="block text-xs text-gray-600 mb-1">
+            <input type="checkbox" id="popover-keep" /> 保留为观察
+        </label>
+        <label class="block text-xs text-gray-600 mb-2">
+            为何重要？
+            <textarea id="popover-annotation" rows="2" class="mt-1 w-full border border-gray-300 rounded px-2 py-1 text-sm" placeholder="简要说明…"></textarea>
+        </label>
+        <div class="flex gap-2">
+            <button type="button" id="popover-save" class="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700">保存</button>
+            <button type="button" id="popover-cancel" class="px-3 py-1.5 text-sm bg-gray-200 text-gray-800 rounded hover:bg-gray-300">取消</button>
+        </div>
+    </div>
+
+    <script>
+        var PASSAGE_REF = "{{ passage_ref }}";
+        var STORAGE_KEY = 'socratic_observations_' + PASSAGE_REF;
+        var EVENTS_ORDER_KEY = 'socratic_events_order_' + PASSAGE_REF;
+        var EVENTS_CARDS_KEY = 'socratic_events_cards_' + PASSAGE_REF;
+        var EXPLANATION_KEY = 'socratic_explanation_questions_' + PASSAGE_REF;
+        var EVENT_CARDS = [];
+        var PENDING_EXPLANATION_QUESTIONS = [];
+        try { EVENT_CARDS = JSON.parse(document.getElementById('event-cards-json').textContent); } catch (e) {}
+        try {
+            var cached = localStorage.getItem(EVENTS_CARDS_KEY);
+            if (cached) { var arr = JSON.parse(cached); if (Array.isArray(arr) && arr.length > 0) EVENT_CARDS = arr; }
+        } catch (e) {}
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text == null ? '' : text;
+            return div.innerHTML;
+        }
+
+        function getObservations() {
+            try {
+                var raw = localStorage.getItem(STORAGE_KEY);
+                if (!raw) return {};
+                var data = JSON.parse(raw);
+                return typeof data === 'object' && data !== null ? data : {};
+            } catch (e) {
+                return {};
+            }
+        }
+
+        function setObservations(data) {
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+            } catch (e) {}
+        }
+
+        function getExplanationQuestions() {
+            try {
+                var raw = localStorage.getItem(EXPLANATION_KEY);
+                if (!raw) return [];
+                var arr = JSON.parse(raw);
+                return Array.isArray(arr) ? arr : [];
+            } catch (e) {
+                return [];
+            }
+        }
+        function setExplanationQuestions(arr) {
+            try {
+                localStorage.setItem(EXPLANATION_KEY, JSON.stringify(arr));
+            } catch (e) {}
+        }
+
+        /** Return unique labels from kept observations (who only for 动机 dropdown). */
+        function getKeptObservationLabels(whoOnly) {
+            var observations = getObservations();
+            var kept = Object.keys(observations).filter(function(id) { return observations[id].kept; });
+            var seen = {};
+            var labels = [];
+            kept.forEach(function(id) {
+                var o = observations[id];
+                var type = (o.type === 'who' || o.type === 'when' || o.type === 'where') ? o.type : 'who';
+                if (whoOnly && type !== 'who') return;
+                var label = (o.label || id).trim();
+                var key = label + '|' + type;
+                if (seen[key]) return;
+                seen[key] = true;
+                labels.push({ label: label, type: type });
+            });
+            return labels;
+        }
+
+        function renderObservationsList() {
+            var observations = getObservations();
+            var list = document.getElementById('observations-list');
+            var kept = Object.keys(observations).filter(function(id) { return observations[id].kept; });
+            // Dedupe by (label, type): only show first occurrence so list has no duplicate labels
+            var seen = {};
+            kept = kept.filter(function(id) {
+                var o = observations[id];
+                var type = (o.type === 'who' || o.type === 'when' || o.type === 'where') ? o.type : 'who';
+                var key = (o.label || id).trim() + '|' + type;
+                if (seen[key]) return false;
+                seen[key] = true;
+                return true;
+            });
+            if (kept.length === 0) {
+                list.innerHTML = '<li class="text-sm text-gray-500">暂无保留的观察。点击经文中高亮词语添加。</li>';
+                return;
+            }
+            list.innerHTML = kept.map(function(entityId) {
+                var o = observations[entityId];
+                var type = (o.type === 'who' || o.type === 'when' || o.type === 'where') ? o.type : 'who';
+                var label = escapeHtml(o.label || entityId);
+                var typeLabel = (type === 'who' ? '谁' : type === 'when' ? '何时' : '何处');
+                var ann = escapeHtml(o.annotation || '');
+                return '<li class="obs-card obs-card-' + type + ' border rounded p-2 text-sm" data-entity-id="' + escapeHtml(entityId) + '">' +
+                    '<span class="font-medium">' + label + '</span> ' +
+                    '<span class="text-gray-500 text-xs">(' + typeLabel + ')</span>' +
+                    (ann ? '<p class="mt-1 text-gray-600">' + ann + '</p>' : '') +
+                    ' <button type="button" class="edit-obs text-blue-600 text-xs">编辑</button>' +
+                    ' <button type="button" class="remove-obs text-gray-500 text-xs">移除</button>' +
+                    '</li>';
+            }).join('');
+
+            list.querySelectorAll('.edit-obs').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var li = btn.closest('li');
+                    var id = li && li.getAttribute('data-entity-id');
+                    if (id) openPopoverFor(id);
+                });
+            });
+            list.querySelectorAll('.remove-obs').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var li = btn.closest('li');
+                    var id = li && li.getAttribute('data-entity-id');
+                    if (!id) return;
+                    var data = getObservations();
+                    var o = data[id];
+                    if (!o) return;
+                    var label = (o.label || '').trim();
+                    var type = (o.type === 'who' || o.type === 'when' || o.type === 'where') ? o.type : 'who';
+                    // Remove from all instances of this term (same label + type)
+                    Object.keys(data).forEach(function(k) {
+                        var other = data[k];
+                        var ol = (other.label || '').trim();
+                        var ot = (other.type === 'who' || other.type === 'when' || other.type === 'where') ? other.type : 'who';
+                        if (ol === label && ot === type) other.kept = false;
+                    });
+                    setObservations(data);
+                    renderObservationsList();
+                });
+            });
+        }
+
+        function renderExplanationList() {
+            var list = getExplanationQuestions();
+            var emptyEl = document.getElementById('explanation-empty');
+            var listBlock = document.getElementById('explanation-list-block');
+            var listUl = document.getElementById('explanation-list');
+            if (list.length === 0) {
+                emptyEl.classList.remove('hidden');
+                listBlock.classList.add('hidden');
+                listUl.innerHTML = '';
+                return;
+            }
+            emptyEl.classList.add('hidden');
+            listBlock.classList.remove('hidden');
+            listUl.innerHTML = list.map(function(q) {
+                var reflection = (q.reflection != null) ? String(q.reflection) : '';
+                return '<li class="question-card border border-gray-200 rounded-lg p-3 bg-white shadow-sm" draggable="true" data-question-id="' + escapeHtml(q.id) + '">' +
+                    '<div class="flex items-start gap-2">' +
+                    '<span class="text-gray-400 mt-0.5 select-none cursor-grab">≡</span>' +
+                    '<span class="question-text text-sm text-gray-800 flex-1">' + escapeHtml(q.text) + '</span>' +
+                    ' <button type="button" class="edit-question text-blue-600 text-xs">编辑</button>' +
+                    ' <button type="button" class="remove-question text-gray-500 text-xs">移除</button>' +
+                    '</div>' +
+                    '<div class="mt-2 ml-6">' +
+                    '<label class="text-xs text-gray-500 block mb-0.5">我的初步想法</label>' +
+                    '<textarea class="expl-reflection w-full border border-gray-300 rounded px-2 py-1 text-sm resize-y min-h-[48px]" rows="1" placeholder="写下你的理解，帮助自己更理解经文…" data-question-id="' + escapeHtml(q.id) + '">' + escapeHtml(reflection) + '</textarea>' +
+                    '</div>' +
+                    '</li>';
+            }).join('');
+
+            listUl.querySelectorAll('.question-card').forEach(function(card) {
+                card.addEventListener('dragstart', onQuestionCardDragStart);
+                card.addEventListener('dragend', onQuestionCardDragEnd);
+            });
+            listUl.querySelectorAll('.question-card').forEach(function(card) {
+                card.addEventListener('dragover', onQuestionCardDragOver);
+                card.addEventListener('drop', onQuestionCardDrop);
+                card.addEventListener('dragleave', onQuestionCardDragLeave);
+            });
+            listUl.querySelectorAll('.edit-question').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var li = btn.closest('li');
+                    var id = li && li.getAttribute('data-question-id');
+                    if (!id) return;
+                    var questions = getExplanationQuestions();
+                    var q = questions.find(function(x) { return x.id === id; });
+                    if (!q) return;
+                    li.innerHTML = '<span class="text-gray-400 mt-0.5 select-none">≡</span>' +
+                        '<textarea class="expl-edit-text flex-1 border border-gray-300 rounded px-2 py-1 text-sm min-h-[60px]" rows="2">' + escapeHtml(q.text) + '</textarea>' +
+                        ' <button type="button" class="expl-edit-save text-blue-600 text-xs">保存</button>' +
+                        ' <button type="button" class="expl-edit-cancel text-gray-500 text-xs">取消</button>';
+                    var textarea = li.querySelector('.expl-edit-text');
+                    li.querySelector('.expl-edit-save').addEventListener('click', function() {
+                        var newText = (textarea.value || '').trim();
+                        if (newText) {
+                            q.text = newText;
+                            setExplanationQuestions(questions);
+                        }
+                        renderExplanationList();
+                    });
+                    li.querySelector('.expl-edit-cancel').addEventListener('click', function() { renderExplanationList(); });
+                    textarea.focus();
+                });
+            });
+            listUl.querySelectorAll('.remove-question').forEach(function(btn) {
+                btn.addEventListener('click', removeQuestionHandler);
+            });
+            listUl.querySelectorAll('.expl-reflection').forEach(function(textarea) {
+                textarea.addEventListener('blur', function() {
+                    var id = textarea.getAttribute('data-question-id');
+                    if (!id) return;
+                    var questions = getExplanationQuestions();
+                    var q = questions.find(function(x) { return x.id === id; });
+                    if (!q) return;
+                    q.reflection = (textarea.value || '').trim();
+                    setExplanationQuestions(questions);
+                });
+            });
+        }
+
+        function removeQuestionHandler(evt) {
+            var li = evt.target.closest('li');
+            var id = li && li.getAttribute('data-question-id');
+            if (!id) return;
+            var questions = getExplanationQuestions().filter(function(q) { return q.id !== id; });
+            setExplanationQuestions(questions);
+            renderExplanationList();
+        }
+
+        var draggedQuestionId = null;
+        function onQuestionCardDragStart(evt) {
+            draggedQuestionId = evt.target.getAttribute('data-question-id');
+            evt.target.classList.add('dragging');
+            evt.dataTransfer.effectAllowed = 'move';
+            evt.dataTransfer.setData('text/plain', draggedQuestionId);
+        }
+        function onQuestionCardDragEnd(evt) {
+            evt.target.classList.remove('dragging');
+            draggedQuestionId = null;
+        }
+        function onQuestionCardDragOver(evt) {
+            evt.preventDefault();
+            evt.dataTransfer.dropEffect = 'move';
+            var card = evt.target.closest('.question-card');
+            if (card && card.getAttribute('data-question-id') !== draggedQuestionId) card.classList.add('drag-over');
+        }
+        function onQuestionCardDragLeave(evt) {
+            var card = evt.target.closest('.question-card');
+            if (card) card.classList.remove('drag-over');
+        }
+        function onQuestionCardDrop(evt) {
+            evt.preventDefault();
+            var card = evt.target.closest('.question-card');
+            if (!card || !draggedQuestionId) return;
+            card.classList.remove('drag-over');
+            var targetId = card.getAttribute('data-question-id');
+            if (targetId === draggedQuestionId) return;
+            var questions = getExplanationQuestions();
+            var order = questions.map(function(q) { return q.id; });
+            var dragIdx = order.indexOf(draggedQuestionId);
+            var targetIdx = order.indexOf(targetId);
+            if (dragIdx === -1 || targetIdx === -1) return;
+            var reordered = questions.slice(0);
+            var removed = reordered.splice(dragIdx, 1)[0];
+            if (dragIdx < targetIdx) targetIdx--;
+            reordered.splice(targetIdx, 0, removed);
+            setExplanationQuestions(reordered);
+            renderExplanationList();
+        }
+
+        var popover = document.getElementById('popover');
+        var popoverLabel = document.getElementById('popover-label');
+        var popoverKeep = document.getElementById('popover-keep');
+        var popoverAnnotation = document.getElementById('popover-annotation');
+        var currentEntityId = null;
+
+        function openPopoverFor(entityId) {
+            var span = document.querySelector('[data-entity-id="' + escapeHtml(entityId) + '"]');
+            if (!span || span.closest('#observations-list')) return;
+            var rect = span.getBoundingClientRect();
+            currentEntityId = entityId;
+            var observations = getObservations();
+            var o = observations[entityId] || { kept: false, annotation: '', label: span.getAttribute('data-entity-label') || entityId, type: span.getAttribute('data-entity-type') || '' };
+            popoverLabel.textContent = o.label || entityId;
+            popoverKeep.checked = o.kept;
+            popoverAnnotation.value = o.annotation || '';
+            popover.classList.remove('hidden');
+            popover.setAttribute('aria-hidden', 'false');
+            // Position with viewport coordinates (popover is position: fixed)
+            var gap = 8;
+            var viewportW = window.innerWidth;
+            var viewportH = window.innerHeight;
+            // Measure popover after it is visible
+            var popW = popover.offsetWidth;
+            var popH = popover.offsetHeight;
+            var top = rect.bottom + 4;
+            if (top + popH > viewportH - gap) {
+                top = rect.top - popH - 4;
+            }
+            if (top < gap) top = gap;
+            var left = rect.left;
+            if (left + popW > viewportW - gap) left = viewportW - popW - gap;
+            if (left < gap) left = gap;
+            popover.style.left = left + 'px';
+            popover.style.top = top + 'px';
+        }
+
+        function closePopover() {
+            popover.classList.add('hidden');
+            popover.setAttribute('aria-hidden', 'true');
+            currentEntityId = null;
+        }
+
+        /** Return all entity IDs in the passage that have the same label and type (all instances of that term). */
+        function getPassageEntityIdsByLabelAndType(label, type) {
+            var container = document.getElementById('passage-container');
+            if (!container) return [];
+            var spans = container.querySelectorAll('.entity');
+            var normType = (type === 'who' || type === 'when' || type === 'where') ? type : 'who';
+            var normLabel = (label || '').trim();
+            var ids = [];
+            spans.forEach(function(span) {
+                if (span.getAttribute('data-entity-label') === normLabel && (span.getAttribute('data-entity-type') === normType || (span.getAttribute('data-entity-type') === '' && normType === 'who'))) {
+                    var id = span.getAttribute('data-entity-id');
+                    if (id) ids.push(id);
+                }
+            });
+            return ids;
+        }
+
+        function savePopover() {
+            if (!currentEntityId) return;
+            var observations = getObservations();
+            var o = observations[currentEntityId] || { label: '', type: '' };
+            var span = document.querySelector('[data-entity-id="' + escapeHtml(currentEntityId) + '"]');
+            if (span && !span.closest('#observations-list')) {
+                o.label = span.getAttribute('data-entity-label') || o.label;
+                o.type = span.getAttribute('data-entity-type') || o.type;
+            }
+            o.kept = popoverKeep.checked;
+            o.annotation = (popoverAnnotation.value || '').trim();
+            var label = (o.label || '').trim();
+            var type = (o.type === 'who' || o.type === 'when' || o.type === 'where') ? o.type : 'who';
+            if (o.kept) {
+                // Apply this observation to all instances of this term in the passage
+                var allIds = getPassageEntityIdsByLabelAndType(label, type);
+                allIds.forEach(function(id) {
+                    observations[id] = { kept: true, annotation: o.annotation, label: label, type: type };
+                });
+            } else {
+                // Un-keep all instances of this term
+                var allIds = getPassageEntityIdsByLabelAndType(label, type);
+                allIds.forEach(function(id) {
+                    var existing = observations[id] || { label: label, type: type };
+                    existing.kept = false;
+                    existing.annotation = o.annotation;
+                    observations[id] = existing;
+                });
+            }
+            setObservations(observations);
+            renderObservationsList();
+            closePopover();
+        }
+
+        document.getElementById('popover-save').addEventListener('click', savePopover);
+        document.getElementById('popover-cancel').addEventListener('click', closePopover);
+
+        document.getElementById('passage-container').addEventListener('click', function(evt) {
+            var span = evt.target.closest('.entity');
+            if (!span) return;
+            evt.preventDefault();
+            openPopoverFor(span.getAttribute('data-entity-id'));
+        });
+
+        document.querySelectorAll('.toggle-btn').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                var type = btn.getAttribute('data-type');
+                var container = document.getElementById('passage-container');
+                if (!container) return;
+                var cls = 'hide-' + type;
+                if (container.classList.contains(cls)) {
+                    container.classList.remove(cls);
+                    btn.classList.remove('opacity-50');
+                } else {
+                    container.classList.add(cls);
+                    btn.classList.add('opacity-50');
+                }
+            });
+        });
+
+        function getEventsOrder() {
+            try {
+                var raw = localStorage.getItem(EVENTS_ORDER_KEY);
+                if (!raw) return [];
+                var arr = JSON.parse(raw);
+                return Array.isArray(arr) ? arr : [];
+            } catch (e) { return []; }
+        }
+        function setEventsOrder(ids) {
+            try { localStorage.setItem(EVENTS_ORDER_KEY, JSON.stringify(ids)); } catch (e) {}
+        }
+        function getEventsCards() {
+            try {
+                var raw = localStorage.getItem(EVENTS_CARDS_KEY);
+                if (!raw) return [];
+                var arr = JSON.parse(raw);
+                return Array.isArray(arr) ? arr : [];
+            } catch (e) { return []; }
+        }
+        function setEventsCards(cards) {
+            try { localStorage.setItem(EVENTS_CARDS_KEY, JSON.stringify(cards)); } catch (e) {}
+        }
+        function shuffleArray(arr) {
+            for (var i = arr.length - 1; i > 0; i--) {
+                var j = Math.floor(Math.random() * (i + 1));
+                var t = arr[i]; arr[i] = arr[j]; arr[j] = t;
+            }
+            return arr;
+        }
+
+        function showObservationPanel() {
+            document.getElementById('panel-observation').classList.add('active');
+            document.getElementById('panel-sequence').classList.remove('active');
+            document.getElementById('panel-explanation').classList.remove('active');
+            var container = document.getElementById('passage-container');
+            if (container) container.classList.remove('only-kept-highlights');
+            document.querySelectorAll('#passage-container .entity').forEach(function(el) { el.classList.remove('entity-kept'); });
+        }
+        function showSequencePanel() {
+            document.getElementById('panel-observation').classList.remove('active');
+            document.getElementById('panel-sequence').classList.add('active');
+            document.getElementById('panel-explanation').classList.remove('active');
+            var observations = getObservations();
+            var keptIds = Object.keys(observations).filter(function(id) { return observations[id].kept; });
+            var keptSet = {};
+            keptIds.forEach(function(id) { keptSet[id] = true; });
+            document.querySelectorAll('#passage-container .entity').forEach(function(el) {
+                var id = el.getAttribute('data-entity-id');
+                if (id && keptSet[id]) el.classList.add('entity-kept');
+                else el.classList.remove('entity-kept');
+            });
+            document.getElementById('passage-container').classList.add('only-kept-highlights');
+            var list = document.getElementById('sequence-list');
+            if (EVENT_CARDS.length === 0) EVENT_CARDS = getEventsCards();
+            if (EVENT_CARDS.length > 0) {
+                renderSequenceCards();
+                return;
+            }
+            list.innerHTML = '<li class="text-sm text-gray-500 py-4">正在生成 3–5 个主要事件…</li>';
+            fetch('/api/events')
+                .then(function(r) { return r.json(); })
+                .then(function(events) {
+                    if (Array.isArray(events) && events.length > 0) {
+                        EVENT_CARDS = events;
+                        setEventsCards(events);
+                        var ids = events.map(function(c) { return c.id; });
+                        setEventsOrder(shuffleArray(ids.slice(0)));
+                        renderSequenceCards();
+                    } else {
+                        list.innerHTML = '<li class="text-sm text-gray-500 py-4">暂无事件。请确认已设置 GROQ_API_KEY。</li>';
+                    }
+                })
+                .catch(function() {
+                    list.innerHTML = '<li class="text-sm text-red-600 py-4">加载失败，请稍后重试。</li>';
+                });
+        }
+
+        function renderSequenceCards() {
+            var list = document.getElementById('sequence-list');
+            if (EVENT_CARDS.length === 0) return;
+            var order = getEventsOrder();
+            var ids = order.length === EVENT_CARDS.length ? order : EVENT_CARDS.map(function(c) { return c.id; });
+            var byId = {};
+            EVENT_CARDS.forEach(function(c) { byId[c.id] = c; });
+            var ordered = ids.filter(function(id) { return byId[id]; }).map(function(id) { return byId[id]; });
+            var missing = EVENT_CARDS.filter(function(c) { return ids.indexOf(c.id) === -1; });
+            ordered = ordered.concat(missing);
+            setEventsOrder(ordered.map(function(c) { return c.id; }));
+
+            list.innerHTML = ordered.map(function(card, index) {
+                return '<li class="event-card border border-gray-200 rounded-lg p-3 bg-white shadow-sm flex items-start gap-2" draggable="true" data-event-id="' + escapeHtml(card.id) + '">' +
+                    '<span class="text-gray-400 mt-0.5 select-none">' + (index + 1) + '.</span>' +
+                    '<span class="text-sm text-gray-800 flex-1">' + escapeHtml(card.label) + '</span>' +
+                    '</li>';
+            }).join('');
+
+            list.querySelectorAll('.event-card').forEach(function(card) {
+                card.addEventListener('dragstart', onEventCardDragStart);
+                card.addEventListener('dragend', onEventCardDragEnd);
+            });
+            list.querySelectorAll('.event-card').forEach(function(card) {
+                card.addEventListener('dragover', onEventCardDragOver);
+                card.addEventListener('drop', onEventCardDrop);
+                card.addEventListener('dragleave', onEventCardDragLeave);
+            });
+        }
+
+        var draggedCardId = null;
+        function onEventCardDragStart(evt) {
+            draggedCardId = evt.target.getAttribute('data-event-id');
+            evt.target.classList.add('dragging');
+            evt.dataTransfer.effectAllowed = 'move';
+            evt.dataTransfer.setData('text/plain', draggedCardId);
+        }
+        function onEventCardDragEnd(evt) {
+            evt.target.classList.remove('dragging');
+            draggedCardId = null;
+        }
+        function onEventCardDragOver(evt) {
+            evt.preventDefault();
+            evt.dataTransfer.dropEffect = 'move';
+            var card = evt.target.closest('.event-card');
+            if (card && card.getAttribute('data-event-id') !== draggedCardId) card.classList.add('drag-over');
+        }
+        function onEventCardDragLeave(evt) {
+            var card = evt.target.closest('.event-card');
+            if (card) card.classList.remove('drag-over');
+        }
+        function onEventCardDrop(evt) {
+            evt.preventDefault();
+            var card = evt.target.closest('.event-card');
+            if (!card || !draggedCardId) return;
+            card.classList.remove('drag-over');
+            var targetId = card.getAttribute('data-event-id');
+            if (targetId === draggedCardId) return;
+            var order = getEventsOrder();
+            var dragIdx = order.indexOf(draggedCardId);
+            var targetIdx = order.indexOf(targetId);
+            if (dragIdx === -1 || targetIdx === -1) return;
+            order.splice(dragIdx, 1);
+            if (dragIdx < targetIdx) targetIdx--;
+            order.splice(targetIdx, 0, draggedCardId);
+            setEventsOrder(order);
+            renderSequenceCards();
+        }
+
+        function showExplanationPanel() {
+            document.getElementById('panel-observation').classList.remove('active');
+            document.getElementById('panel-sequence').classList.remove('active');
+            document.getElementById('panel-explanation').classList.add('active');
+            var labels = getKeptObservationLabels(false);
+            var summaryEl = document.getElementById('explanation-kept-summary');
+            if (labels.length > 0) {
+                summaryEl.textContent = '你保留了：' + labels.map(function(x) { return x.label; }).join('、');
+                summaryEl.classList.remove('hidden');
+            } else {
+                summaryEl.textContent = '';
+                summaryEl.classList.add('hidden');
+            }
+            document.getElementById('explanation-template-form').classList.add('hidden');
+            document.getElementById('explanation-freeform-form').classList.add('hidden');
+            renderExplanationList();
+        }
+
+        document.getElementById('btn-next').addEventListener('click', showSequencePanel);
+        document.getElementById('btn-sequence-back').addEventListener('click', showObservationPanel);
+        document.getElementById('btn-sequence-next').addEventListener('click', showExplanationPanel);
+        document.getElementById('btn-explanation-back').addEventListener('click', showSequencePanel);
+
+        function showExplanationTemplateForm() {
+            var form = document.getElementById('explanation-template-form');
+            var typeWrap = form.querySelector('#expl-template-target-wrap');
+            var cultureWrap = document.getElementById('expl-template-culture-wrap');
+            var whoSelect = document.getElementById('expl-template-who');
+            var targetSelect = document.getElementById('expl-template-target');
+            var textArea = document.getElementById('expl-template-text');
+            var whoLabels = getKeptObservationLabels(true);
+            var allLabels = getKeptObservationLabels(false);
+            var eventLabels = (EVENT_CARDS || []).map(function(c) { return c.label; });
+            whoSelect.innerHTML = whoLabels.map(function(x) { return '<option value="' + escapeHtml(x.label) + '">' + escapeHtml(x.label) + '</option>'; }).join('');
+            targetSelect.innerHTML = allLabels.map(function(x) { return '<option value="' + x.label + '">' + escapeHtml(x.label) + '</option>'; }).join('');
+            eventLabels.forEach(function(l) {
+                var opt = document.createElement('option');
+                opt.value = l;
+                opt.textContent = l;
+                targetSelect.appendChild(opt);
+            });
+            form.querySelector('input[name="expl-template-type"][value="motive"]').checked = true;
+            typeWrap.classList.remove('hidden');
+            cultureWrap.classList.add('hidden');
+            textArea.value = whoLabels.length ? (whoLabels[0].label + '这样说/这样做，可能在想什么？') : '［人物］这样说/这样做，可能在想什么？';
+            form.classList.remove('hidden');
+        }
+        function updateExplanationTemplatePrefill() {
+            var form = document.getElementById('explanation-template-form');
+            var checked = form.querySelector('input[name="expl-template-type"]:checked');
+            var type = checked ? checked.value : 'motive';
+            var whoSelect = document.getElementById('expl-template-who');
+            var targetSelect = document.getElementById('expl-template-target');
+            var textArea = document.getElementById('expl-template-text');
+            var typeWrap = document.getElementById('expl-template-target-wrap');
+            var cultureWrap = document.getElementById('expl-template-culture-wrap');
+            if (type === 'motive') {
+                typeWrap.classList.remove('hidden');
+                cultureWrap.classList.add('hidden');
+                var who = (whoSelect && whoSelect.value) || '';
+                textArea.value = who ? (who + '这样说/这样做，可能在想什么？') : '［人物］这样说/这样做，可能在想什么？';
+            } else if (type === 'culture') {
+                typeWrap.classList.add('hidden');
+                cultureWrap.classList.remove('hidden');
+                var t = (targetSelect && targetSelect.value) || '';
+                textArea.value = t ? ('关于' + t + '，当时的人可能会怎样理解？') : '关于［某观察或事件］，当时的人可能会怎样理解？';
+            } else {
+                typeWrap.classList.add('hidden');
+                cultureWrap.classList.add('hidden');
+                textArea.value = '这段经文在这里想表达什么？';
+            }
+        }
+        document.getElementById('btn-template-first').addEventListener('click', showExplanationTemplateForm);
+        document.getElementById('btn-template-add').addEventListener('click', showExplanationTemplateForm);
+        document.getElementById('explanation-template-form').addEventListener('change', function(evt) {
+            if (evt.target.name === 'expl-template-type' || evt.target.id === 'expl-template-who' || evt.target.id === 'expl-template-target') updateExplanationTemplatePrefill();
+        });
+        document.getElementById('expl-template-submit').addEventListener('click', function() {
+            var text = (document.getElementById('expl-template-text').value || '').trim();
+            if (!text) return;
+            var questions = getExplanationQuestions();
+            questions.push({ id: 'eq_' + Date.now(), text: text });
+            setExplanationQuestions(questions);
+            document.getElementById('explanation-template-form').classList.add('hidden');
+            renderExplanationList();
+        });
+        document.getElementById('expl-template-cancel').addEventListener('click', function() {
+            document.getElementById('explanation-template-form').classList.add('hidden');
+        });
+
+        document.getElementById('btn-add-question').addEventListener('click', function() {
+            document.getElementById('explanation-freeform-form').classList.remove('hidden');
+            document.getElementById('expl-freeform-text').value = '';
+            document.getElementById('expl-freeform-text').focus();
+        });
+        document.getElementById('expl-freeform-submit').addEventListener('click', function() {
+            var text = (document.getElementById('expl-freeform-text').value || '').trim();
+            if (!text) return;
+            var questions = getExplanationQuestions();
+            questions.push({ id: 'eq_' + Date.now(), text: text });
+            setExplanationQuestions(questions);
+            document.getElementById('explanation-freeform-form').classList.add('hidden');
+            renderExplanationList();
+        });
+        document.getElementById('expl-freeform-cancel').addEventListener('click', function() {
+            document.getElementById('explanation-freeform-form').classList.add('hidden');
+        });
+
+        function fetchAndShowExplanationMergeModal() {
+            var btnFirst = document.getElementById('btn-generate-first');
+            var btnMore = document.getElementById('btn-generate-more');
+            var origFirst = btnFirst.textContent;
+            var origMore = btnMore.textContent;
+            btnFirst.disabled = true;
+            btnMore.disabled = true;
+            btnFirst.textContent = '生成中…';
+            btnMore.textContent = '生成中…';
+            fetch('/api/explanation-questions')
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    btnFirst.disabled = false;
+                    btnMore.disabled = false;
+                    btnFirst.textContent = origFirst;
+                    btnMore.textContent = origMore;
+                    PENDING_EXPLANATION_QUESTIONS = Array.isArray(data) ? data : [];
+                    var modal = document.getElementById('explanation-merge-modal');
+                    var radio = modal.querySelector('input[name="expl-merge-mode"][value="' + (getExplanationQuestions().length > 0 ? 'append' : 'replace') + '"]');
+                    if (radio) radio.checked = true;
+                    modal.classList.remove('hidden');
+                    modal.setAttribute('aria-hidden', 'false');
+                })
+                .catch(function() {
+                    btnFirst.disabled = false;
+                    btnMore.disabled = false;
+                    btnFirst.textContent = origFirst;
+                    btnMore.textContent = origMore;
+                    alert('加载失败，请稍后重试。');
+                });
+        }
+        document.getElementById('btn-generate-first').addEventListener('click', fetchAndShowExplanationMergeModal);
+        document.getElementById('btn-generate-more').addEventListener('click', fetchAndShowExplanationMergeModal);
+        document.getElementById('expl-merge-confirm').addEventListener('click', function() {
+            var mode = (document.querySelector('input[name="expl-merge-mode"]:checked') || {}).value;
+            var existing = getExplanationQuestions();
+            if (mode === 'replace') {
+                setExplanationQuestions(PENDING_EXPLANATION_QUESTIONS.slice(0));
+            } else {
+                var seen = {};
+                existing.forEach(function(q) { seen[q.text] = true; });
+                PENDING_EXPLANATION_QUESTIONS.forEach(function(q) {
+                    if (!seen[q.text]) {
+                        seen[q.text] = true;
+                        existing.push({ id: q.id || ('eq_' + Date.now() + '_' + Math.random().toString(36).slice(2)), text: q.text });
+                    }
+                });
+                setExplanationQuestions(existing);
+            }
+            PENDING_EXPLANATION_QUESTIONS = [];
+            document.getElementById('explanation-merge-modal').classList.add('hidden');
+            document.getElementById('explanation-merge-modal').setAttribute('aria-hidden', 'true');
+            renderExplanationList();
+        });
+        document.getElementById('expl-merge-cancel').addEventListener('click', function() {
+            PENDING_EXPLANATION_QUESTIONS = [];
+            document.getElementById('explanation-merge-modal').classList.add('hidden');
+            document.getElementById('explanation-merge-modal').setAttribute('aria-hidden', 'true');
+            renderExplanationList();
+        });
+
+        renderObservationsList();
+    </script>
+</body>
+</html>

--- a/apps/socratic/__init__.py
+++ b/apps/socratic/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone Socratic coach throwaway app — AI prompts user, user responds, AI only questions or hints."""

--- a/apps/socratic/app.py
+++ b/apps/socratic/app.py
@@ -39,6 +39,7 @@ def index(request: Request):
     """Landing: passage (three versions) + first AI message + form."""
     # Default tab is 简体, so show first question in Simplified Chinese to match
     messages = [{"role": "assistant", "content": FIRST_QUESTION_ZH_SIMPLIFIED}]
+    initial_encoded = _encode_messages(messages)
     return templates.TemplateResponse(
         "index.html",
         {
@@ -46,7 +47,8 @@ def index(request: Request):
             "passage": PASSAGE,
             "passage_verses": get_passage_verses(PASSAGE),
             "messages": messages,
-            "messages_encoded": _encode_messages(messages),
+            "messages_encoded": initial_encoded,
+            "initial_messages_encoded": initial_encoded,
         },
     )
 

--- a/apps/socratic/app.py
+++ b/apps/socratic/app.py
@@ -1,0 +1,93 @@
+"""FastAPI app for Socratic coach — standalone throwaway."""
+
+import json
+import base64
+from pathlib import Path
+
+from fastapi import FastAPI, Request, Form
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+
+from .passages import PASSAGE, get_passage_verses
+from .prompts import SOCRATIC_SYSTEM_PROMPT, FIRST_QUESTION_ZH_SIMPLIFIED, get_coach_language_instruction
+from .llm import socratic_reply
+from .verse_parser import parse_verse_ranges
+
+app = FastAPI(title="Socratic Coach", description="AI-led Socratic dialogue for Bible study prep")
+_TEMPLATES_DIR = Path(__file__).resolve().parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+
+def _decode_messages(value: str) -> list[dict[str, str]]:
+    """Decode conversation history from form (base64 JSON)."""
+    if not value:
+        return []
+    try:
+        raw = base64.b64decode(value).decode("utf-8")
+        return json.loads(raw)
+    except Exception:
+        return []
+
+
+def _encode_messages(messages: list[dict[str, str]]) -> str:
+    """Encode conversation history for form (base64 JSON)."""
+    return base64.b64encode(json.dumps(messages).encode("utf-8")).decode("ascii")
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request):
+    """Landing: passage (three versions) + first AI message + form."""
+    # Default tab is 简体, so show first question in Simplified Chinese to match
+    messages = [{"role": "assistant", "content": FIRST_QUESTION_ZH_SIMPLIFIED}]
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "passage": PASSAGE,
+            "passage_verses": get_passage_verses(PASSAGE),
+            "messages": messages,
+            "messages_encoded": _encode_messages(messages),
+        },
+    )
+
+
+@app.post("/reply", response_class=HTMLResponse)
+def reply(
+    request: Request,
+    user_message: str = Form(..., alias="user_message"),
+    messages_encoded: str = Form("", alias="messages_encoded"),
+    coach_lang: str = Form("simplified", alias="coach_lang"),
+):
+    """Append user message, call LLM, return HTMX fragment with AI reply + form."""
+    messages = _decode_messages(messages_encoded)
+    messages.append({"role": "user", "content": user_message.strip()})
+
+    lang = (coach_lang or "").strip().lower()
+    if lang not in ("simplified", "traditional", "niv"):
+        lang = "simplified"
+    language_instruction = get_coach_language_instruction(coach_lang)
+    passage_verses = get_passage_verses(PASSAGE)[lang]
+    passage_blurb = "\n".join(f'{v["n"]} {v["text"]}' for v in passage_verses)
+    passage_context = (
+        "\n\nPassage text (Luke 7:36-50; cite verse numbers only from this list):\n"
+        + passage_blurb
+    )
+    effective_prompt = (
+        SOCRATIC_SYSTEM_PROMPT + "\n\n" + language_instruction + passage_context
+    )
+    reply_text = socratic_reply(messages, effective_prompt)
+    messages.append({"role": "assistant", "content": reply_text})
+
+    highlight_verses = parse_verse_ranges(reply_text)
+    # Render partial to string so we can return HTMLResponse with HX-Trigger header
+    # (TemplateResponse does not reliably allow mutating headers in all Starlette versions)
+    template = templates.env.get_template("partials/thread_and_form.html")
+    body = template.render(
+        request=request,
+        messages=messages,
+        messages_encoded=_encode_messages(messages),
+    )
+    return HTMLResponse(
+        content=body,
+        headers={"HX-Trigger": json.dumps({"highlightVerses": highlight_verses})},
+    )

--- a/apps/socratic/llm.py
+++ b/apps/socratic/llm.py
@@ -1,0 +1,43 @@
+"""Thin wrapper around LiteLLM for Socratic coach responses."""
+
+import os
+from typing import List, Dict, Any
+
+try:
+    from litellm import completion
+except ImportError:
+    completion = None  # type: ignore
+
+
+def _has_api_key() -> bool:
+    """True if GROQ_API_KEY is set (used for groq/gpt-oss-120b)."""
+    return bool(os.environ.get("GROQ_API_KEY"))
+
+
+def socratic_reply(
+    messages: List[Dict[str, str]],
+    system_prompt: str,
+    model: str = "groq/openai/gpt-oss-120b",
+) -> str:
+    """
+    Call the LLM with conversation history and system prompt via LiteLLM.
+    Returns the assistant's reply (next question or hint only).
+    Uses Groq gpt-oss-120b by default; set GROQ_API_KEY.
+    """
+    if completion is None:
+        return "LiteLLM is not installed. Install with: pip install litellm"
+    if not _has_api_key():
+        return "No API key set. Set GROQ_API_KEY to use the coach."
+
+    full_messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": system_prompt},
+        *messages,
+    ]
+
+    response = completion(
+        model=model,
+        messages=full_messages,
+        temperature=0.7,
+    )
+    content = response.choices[0].message.content
+    return (content or "").strip()

--- a/apps/socratic/passages.py
+++ b/apps/socratic/passages.py
@@ -1,0 +1,88 @@
+"""Passage text in three versions: Simplified Chinese, Traditional Chinese, NIV English."""
+
+import re
+from typing import TypedDict
+
+# Luke 7:36-50 — 耶穌在西門家 / Jesus at Simon the Pharisee's house
+# Sources: NIV (Bible Gateway), CUV Traditional, CUV Simplified (Chinese Union Version)
+
+
+class Verse(TypedDict):
+    n: int
+    text: str
+
+
+def _split_chinese_verses(text: str) -> list[Verse]:
+    """Split Chinese passage (one verse per line, leading digit(s))."""
+    verses: list[Verse] = []
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+        m = re.match(r"^(\d+)\s*(.*)$", line)
+        if m:
+            verses.append({"n": int(m.group(1)), "text": (m.group(2) or "").strip() or line})
+        else:
+            verses.append({"n": 0, "text": line})
+    return verses
+
+
+def _split_niv_verses(text: str) -> list[Verse]:
+    """Split NIV passage (inline verse numbers like '36 When... 37 A woman...')."""
+    # Split on " number " to get boundaries; first segment is empty or leading, then (num, content) pairs
+    parts = re.split(r"\s+(\d+)\s+", text.strip())
+    verses: list[Verse] = []
+    i = 1
+    while i < len(parts) - 1:
+        num = int(parts[i])
+        content = (parts[i + 1] or "").strip()
+        verses.append({"n": num, "text": content})
+        i += 2
+    return verses
+
+
+def get_passage_verses(passage: dict) -> dict[str, list[Verse]]:
+    """Return passage as verse lists for simplified, traditional, niv."""
+    return {
+        "simplified": _split_chinese_verses(passage["simplified"]),
+        "traditional": _split_chinese_verses(passage["traditional"]),
+        "niv": _split_niv_verses(passage["niv"]),
+    }
+
+LUKE_7_36_50 = {
+    "reference_zh": "路加福音 7:36–50",
+    "reference_en": "Luke 7:36–50",
+    "simplified": """36 有一个法利赛人请耶稣和他吃饭；耶稣就到法利赛人家里去坐席。
+37 那城里有一个女人，是个罪人，知道耶稣在法利赛人家里坐席，就拿着盛香膏的玉瓶，
+38 站在耶稣背後，挨着他的脚哭，眼泪湿了耶稣的脚，就用自己的头发擦乾，又用嘴连连亲他的脚，把香膏抹上。
+39 请耶稣的法利赛人看见这事，心里说：这人若是先知，必知道摸他的是谁，是个怎样的女人，乃是个罪人。
+40 耶稣对他说：西门！我有句话要对你说。西门说：夫子，请说。
+41 耶稣说：一个债主有两个人欠他的债；一个欠五十两银子，一个欠五两银子；
+42 因为他们无力偿还，债主就开恩免了他们两个人的债。这两个人那一个更爱他呢？
+43 西门回答说：我想是那多得恩免的人。耶稣说：你断的不错。
+44 於是转过来向着那女人，便对西门说：你看见这女人麽？我进了你的家，你没有给我水洗脚；但这女人用眼泪湿了我的脚，用头发擦乾。
+45 你没有与我亲嘴；但这女人从我进来的时候就不住的用嘴亲我的脚。
+46 你没有用油抹我的头；但这女人用香膏抹我的脚。
+47 所以我告诉你，他许多的罪都赦免了，因为他的爱多；但那赦免少的，他的爱就少。
+48 於是对那女人说：你的罪赦免了。
+49 同席的人心里说：这是甚麽人，竟赦免人的罪呢？
+50 耶稣对那女人说：你的信救了你；平平安安的回去罢！""",
+    "traditional": """36 有一個法利賽人請耶穌和他吃飯；耶穌就到法利賽人家裡去坐席。
+37 那城裡有一個女人，是個罪人，知道耶穌在法利賽人家裡坐席，就拿著盛香膏的玉瓶，
+38 站在耶穌背後，挨著他的腳哭，眼淚溼了耶穌的腳，就用自己的頭髮擦乾，又用嘴連連親他的腳，把香膏抹上。
+39 請耶穌的法利賽人看見這事，心裡說：這人若是先知，必知道摸他的是誰，是個怎樣的女人，乃是個罪人。
+40 耶穌對他說：西門！我有句話要對你說。西門說：夫子，請說。
+41 耶穌說：一個債主有兩個人欠他的債；一個欠五十兩銀子，一個欠五兩銀子；
+42 因為他們無力償還，債主就開恩免了他們兩個人的債。這兩個人那一個更愛他呢？
+43 西門回答說：我想是那多得恩免的人。耶穌說：你斷的不錯。
+44 於是轉過頭來向著那女人，便對西門說：你看見這女人麼？我進了你家，你沒有給我水洗腳；但這女人用眼淚溼了我的腳，用頭髮擦乾。
+45 你沒有與我親嘴；但這女人從我進來的時候就不住的用嘴親我的腳。
+46 你沒有用油抹我的頭；但這女人用香膏抹我的腳。
+47 所以我告訴你，他許多的罪都赦免了，因為他的愛多；但那赦免少的，他的愛就少。
+48 於是對那女人說：你的罪赦免了。
+49 同席的人心裡說：這是甚麼人，竟赦免人的罪呢？
+50 耶穌對那女人說：你的信救了你；平平安安的回去罷！""",
+    "niv": """36 When one of the Pharisees invited Jesus to have dinner with him, he went to the Pharisee's house and reclined at the table. 37 A woman in that town who lived a sinful life learned that Jesus was eating at the Pharisee's house, so she came there with an alabaster jar of perfume. 38 As she stood behind him at his feet weeping, she began to wet his feet with her tears. Then she wiped them with her hair, kissed them and poured perfume on them. 39 When the Pharisee who had invited him saw this, he said to himself, "If this man were a prophet, he would know who is touching him and what kind of woman she is—that she is a sinner." 40 Jesus answered him, "Simon, I have something to tell you." "Tell me, teacher," he said. 41 "Two people owed money to a certain moneylender. One owed him five hundred denarii, and the other fifty. 42 Neither of them had the money to pay him back, so he forgave the debts of both. Now which of them will love him more?" 43 Simon replied, "I suppose the one who had the bigger debt forgiven." "You have judged correctly," Jesus said. 44 Then he turned toward the woman and said to Simon, "Do you see this woman? I came into your house. You did not give me any water for my feet, but she wet my feet with her tears and wiped them with her hair. 45 You did not give me a kiss, but this woman, from the time I entered, has not stopped kissing my feet. 46 You did not put oil on my head, but she has poured perfume on my feet. 47 Therefore, I tell you, her many sins have been forgiven—as her great love has shown. But whoever has been forgiven little loves little." 48 Then Jesus said to her, "Your sins are forgiven." 49 The other guests began to say among themselves, "Who is this who even forgives sins?" 50 Jesus said to the woman, "Your faith has saved you; go in peace." """,
+}
+
+PASSAGE = LUKE_7_36_50

--- a/apps/socratic/prompts.py
+++ b/apps/socratic/prompts.py
@@ -1,0 +1,47 @@
+"""System prompt and instructions for the Socratic coach."""
+
+SOCRATIC_SYSTEM_PROMPT = """You are a Socratic coach helping someone prepare to lead a Bible study. Your role is to ask questions and give brief hints so they think for themselves. You must NEVER:
+
+- State what the main message or meaning of the passage is
+- Do the interpretation for them
+- Give a "correct answer" to what the passage teaches
+- Say that you don't understand, or speak as if you are confused (e.g. "I don't understand the connection"). Only the learner expresses confusion; you are the guide. If you want them to clarify, ask them: "How would you connect these two parts?" not "I don't understand the connection."
+
+You MUST only:
+- Ask follow-up questions (e.g. "Why do you think that?" "What in the text supports that?" "What would someone who disagreed point to?")
+- Ask them to show their work ("Walk me through how you got from the text to that conclusion")
+- If they say they don't know or are stuck: give a SHORT hint only (e.g. "Look at who is speaking in v.44–46" or "What changes between the start and end of the passage?") but never state the answer. When pointing them to a location in the passage, cite specific verse numbers (e.g. "verses 38–42" or "v. 44–48") so they can see exactly where to look.
+
+CRITICAL — Emotional encouragement: Before your next question, briefly affirm their attempt. When they answer (even if partly off or incomplete), say something like: "That's a good attempt," "You're on the right track," "That's a helpful observation," "Good—you're noticing the contrast," or "That's a great answer." Then ask your follow-up question. Do this every time they respond so they feel encouraged, not interrogated. When they say "I don't know" or struggle, still encourage: "No problem—here's a hint to try."
+
+CRITICAL — Don't stay in a question loop forever: Evaluate the *totality* of their answers over the whole conversation. When their synthesis (across multiple turns) shows they have grasped the passage well—e.g. they connect the woman's love and actions to forgiveness, the contrast with Simon, the parable of the two debtors, and Jesus' authority to forgive—then transition. Acknowledge what *they* have said (e.g. "You've drawn out the link between forgiveness and love, and the contrast with Simon's attitude") and ask a wrap-up question instead of another Socratic question: "Do you feel good about your understanding?" or "Does this feel ready to lead from, or is there anything you'd like to revisit?" You are not stating the "correct answer"; you are recognizing that *their* synthesis is sound and inviting them to own it. If they say they're not sure or want to go deeper, return to one more question or hint. Otherwise, let the conversation land.
+
+CRITICAL — When they flag confusion, step back instead of doubling down: If the learner says something "doesn't sit right," asks "is there a grammatical issue?," or wonders whether someone "earned" something, do NOT simply repeat "look at verses X–Y again" in the same translation. First name the core issue (e.g. "You're pinpointing the cause-and-effect question: does love lead to forgiveness, or does forgiveness lead to love?"). Then offer a different path: suggest they compare the same verses in another translation (they have 简体, 繁體, and NIV in the app—e.g. "If the Chinese feels ambiguous here, try reading 47–48 in the NIV; the sentence structure can clarify the relationship"), or point to a different part of the passage, or reframe so they can test their reading. Do not ask them to re-read the same verses in the same language multiple times when they have already expressed confusion about meaning or grammar there.
+
+CRITICAL — Use other translations when one obscures meaning: The learner can switch between Simplified Chinese, Traditional Chinese, and NIV in this app. When the passage in their current translation is ambiguous (e.g. cause-effect, grammar, or key terms), suggest they look at the same verses in another translation. For example: "If the wording in your version blurs cause and effect, try the same verses in NIV [or the other Chinese]—the structure there might help." Do not assume one translation is sufficient when they are stuck on how the text actually reads.
+
+Keep each response to 2–4 short sentences (or a bit more when you're doing the wrap-up). Stay warm. The passage is Luke 7:36–50 (Jesus at Simon the Pharisee's house, the woman who anoints Jesus' feet)."""
+
+FIRST_QUESTION = "After reading this passage, what do you think is the main message?"
+
+FIRST_QUESTION_ZH = "讀完這段經文後，你覺得這段經文的主要信息是甚麼？"
+
+FIRST_QUESTION_ZH_SIMPLIFIED = "读完这段经文后，你觉得这段经文的主要信息是什么？"
+
+VALID_COACH_LANGS = ("simplified", "traditional", "niv")
+
+
+def get_coach_language_instruction(coach_lang: str) -> str:
+    """Return the language instruction to append to the system prompt.
+
+    Accepts normalized values: simplified | traditional | niv.
+    Invalid or unknown values are treated as simplified.
+    """
+    lang = (coach_lang or "").strip().lower()
+    if lang not in VALID_COACH_LANGS:
+        lang = "simplified"
+    if lang == "simplified":
+        return "Respond only in Simplified Chinese (简体中文). All your messages must be in this language."
+    if lang == "traditional":
+        return "Respond only in Traditional Chinese (繁體中文). All your messages must be in this language."
+    return "Respond only in English. All your messages must be in this language."

--- a/apps/socratic/templates/index.html
+++ b/apps/socratic/templates/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Socratic Coach — 路加福音 7:36–50</title>
+    <script src="https://unpkg.com/htmx.org@1.9.4"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        .passage-panel { display: none; }
+        .passage-panel.active { display: block; }
+        .tab.active { font-weight: 600; border-bottom: 2px solid currentColor; }
+        .verse-highlight { background-color: rgba(250, 204, 21, 0.35); }
+    </style>
+</head>
+<body class="bg-gray-50 text-gray-900 h-screen flex flex-col overflow-hidden">
+    <div class="flex flex-1 min-h-0">
+        <!-- Left: Scripture -->
+        <aside class="w-1/2 flex flex-col border-r border-gray-200 bg-white shrink-0">
+            <div class="px-4 py-3 border-b border-gray-200 shrink-0">
+                <h1 class="text-lg font-semibold">Socratic Coach</h1>
+                <p class="text-sm text-gray-600">{{ passage.reference_zh }} / {{ passage.reference_en }}</p>
+            </div>
+            <div class="flex border-b border-gray-200 shrink-0">
+                <button type="button" class="tab active px-4 py-2 text-sm" data-panel="simplified">简体中文</button>
+                <button type="button" class="tab px-4 py-2 text-sm" data-panel="traditional">繁體中文</button>
+                <button type="button" class="tab px-4 py-2 text-sm" data-panel="niv">NIV English</button>
+            </div>
+            <div class="flex-1 overflow-auto p-4 text-gray-800">
+                <div id="panel-simplified" class="passage-panel active">
+                    {% for v in passage_verses.simplified %}<span data-verse="{{ v.n }}" class="verse block mb-1">{{ v.n }} {{ v.text }}</span>{% endfor %}
+                </div>
+                <div id="panel-traditional" class="passage-panel">
+                    {% for v in passage_verses.traditional %}<span data-verse="{{ v.n }}" class="verse block mb-1">{{ v.n }} {{ v.text }}</span>{% endfor %}
+                </div>
+                <div id="panel-niv" class="passage-panel">
+                    {% for v in passage_verses.niv %}<span data-verse="{{ v.n }}" class="verse block mb-1">{{ v.n }} {{ v.text }}</span>{% endfor %}
+                </div>
+            </div>
+        </aside>
+
+        <!-- Right: Coach conversation -->
+        <main class="flex-1 flex flex-col min-w-0 min-h-0">
+            <div id="conversation" class="flex-1 flex flex-col min-h-0 px-4 py-4">
+                {% include "partials/thread_and_form.html" %}
+            </div>
+        </main>
+    </div>
+
+    <script>
+        document.body.dataset.coachLang = 'simplified';
+        document.querySelectorAll('.tab').forEach(function(btn) {
+            btn.addEventListener('click', function() {
+                document.body.dataset.coachLang = btn.dataset.panel || 'simplified';
+                var langEl = document.getElementById('coach_lang_input');
+                if (langEl) langEl.value = document.body.dataset.coachLang || 'simplified';
+                var panelId = 'panel-' + btn.dataset.panel;
+                document.querySelectorAll('.tab').forEach(function(b) { b.classList.remove('active'); });
+                document.querySelectorAll('.passage-panel').forEach(function(p) { p.classList.remove('active'); });
+                btn.classList.add('active');
+                var panel = document.getElementById(panelId);
+                if (panel) panel.classList.add('active');
+            });
+        });
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            if (evt.detail && evt.detail.target && evt.detail.target.id === 'conversation') {
+                var el = document.getElementById('coach_lang_input');
+                if (el) el.value = document.body.dataset.coachLang || 'simplified';
+            }
+        });
+
+        document.body.addEventListener('highlightVerses', function(evt) {
+            var verses = (evt.detail && evt.detail.value !== undefined) ? evt.detail.value : [];
+            if (!Array.isArray(verses)) verses = [];
+            document.querySelectorAll('.verse').forEach(function(span) {
+                span.classList.remove('verse-highlight');
+            });
+            verses.forEach(function(n) {
+                var num = typeof n === 'number' ? n : parseInt(n, 10);
+                if (isNaN(num)) return;
+                document.querySelectorAll('[data-verse="' + num + '"]').forEach(function(span) {
+                    span.classList.add('verse-highlight');
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/apps/socratic/templates/index.html
+++ b/apps/socratic/templates/index.html
@@ -41,13 +41,149 @@
 
         <!-- Right: Coach conversation -->
         <main class="flex-1 flex flex-col min-w-0 min-h-0">
-            <div id="conversation" class="flex-1 flex flex-col min-h-0 px-4 py-4">
+            <div class="px-4 pt-2 pb-1 border-b border-gray-200 bg-gray-50 shrink-0 flex items-center gap-2 flex-wrap">
+                <button type="button" id="btn-new-session" class="text-sm px-3 py-1.5 bg-white border border-gray-300 rounded hover:bg-gray-100">New conversation</button>
+                <div id="recent-sessions" class="flex items-center gap-2 flex-wrap text-sm text-gray-600"></div>
+            </div>
+            <div id="conversation" class="flex-1 flex flex-col min-h-0 px-4 py-4 overflow-auto" data-initial-messages="{{ initial_messages_encoded }}">
                 {% include "partials/thread_and_form.html" %}
             </div>
         </main>
     </div>
 
     <script>
+        var STORAGE_KEY = 'socratic_sessions';
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function encodeMessages(messages) {
+            return btoa(unescape(encodeURIComponent(JSON.stringify(messages))));
+        }
+
+        function decodeMessages(encoded) {
+            if (!encoded) return [];
+            try {
+                return JSON.parse(decodeURIComponent(escape(atob(encoded))));
+            } catch (e) {
+                return [];
+            }
+        }
+
+        function renderConversation(messages, coachLang) {
+            coachLang = coachLang || document.body.dataset.coachLang || 'simplified';
+            var encoded = encodeMessages(messages);
+            var threadHtml = '<div class="flex-1 overflow-auto pb-4">';
+            for (var i = 0; i < messages.length; i++) {
+                var msg = messages[i];
+                var isAssistant = msg.role === 'assistant';
+                var blockClass = isAssistant ? 'mb-4 bg-blue-50 border-l-4 border-blue-400 pl-4 py-2 rounded-r' : 'mb-4 bg-gray-100 pl-4 py-2 rounded';
+                var label = isAssistant ? 'Coach' : 'You';
+                threadHtml += '<div class="' + blockClass + '">';
+                threadHtml += '<p class="text-xs font-medium text-gray-500 mb-1">' + escapeHtml(label) + '</p>';
+                threadHtml += '<p class="whitespace-pre-wrap">' + escapeHtml(msg.content || '') + '</p></div>';
+            }
+            threadHtml += '</div>';
+            var formHtml = '<div class="shrink-0 border-t border-gray-200 bg-gray-50 pt-4 pb-2">';
+            formHtml += '<form hx-post="/reply" hx-target="#conversation" hx-swap="innerHTML" hx-indicator="#form-spinner">';
+            formHtml += '<input type="hidden" name="messages_encoded" id="messages_encoded_input" value="' + escapeHtml(encoded) + '">';
+            formHtml += '<input type="hidden" name="coach_lang" id="coach_lang_input" value="' + escapeHtml(coachLang) + '">';
+            formHtml += '<label for="user_message" class="block text-sm font-medium text-gray-700 mb-1">Your response</label>';
+            formHtml += '<textarea id="user_message" name="user_message" rows="3" class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 placeholder-gray-500 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white" placeholder="Type your thoughts..." required></textarea>';
+            formHtml += '<div class="mt-2 flex items-center gap-2">';
+            formHtml += '<button type="submit" class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">Send</button>';
+            formHtml += '<span id="form-spinner" class="htmx-indicator text-sm text-gray-500">Thinking...</span></div></form></div>';
+            var container = document.getElementById('conversation');
+            if (container) {
+                container.innerHTML = '<div class="flex flex-col flex-1 min-h-0">' + threadHtml + formHtml + '</div>';
+                if (window.htmx) htmx.process(container);
+            }
+        }
+
+        function getStored() {
+            try {
+                var raw = localStorage.getItem(STORAGE_KEY);
+                if (!raw) return { sessions: {}, currentId: null };
+                var data = JSON.parse(raw);
+                return data && typeof data.sessions === 'object' ? data : { sessions: {}, currentId: null };
+            } catch (e) {
+                return { sessions: {}, currentId: null };
+            }
+        }
+
+        function setStored(data) {
+            try {
+                localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+            } catch (e) {}
+        }
+
+        function saveToStore(messagesEncoded, isNewSession) {
+            var data = getStored();
+            var id = data.currentId;
+            if (!id || isNewSession) {
+                id = crypto.randomUUID && crypto.randomUUID() || 'id-' + Date.now();
+                data.currentId = id;
+            }
+            var messages = decodeMessages(messagesEncoded);
+            var title = '';
+            for (var j = 0; j < messages.length; j++) {
+                if (messages[j].role === 'user' && messages[j].content) {
+                    title = messages[j].content.slice(0, 40);
+                    if (messages[j].content.length > 40) title += '…';
+                    break;
+                }
+            }
+            var now = new Date().toISOString();
+            if (!data.sessions[id]) {
+                data.sessions[id] = { messages_encoded: messagesEncoded, createdAt: now, updatedAt: now, title: title };
+            } else {
+                data.sessions[id].messages_encoded = messagesEncoded;
+                data.sessions[id].updatedAt = now;
+                if (title) data.sessions[id].title = title;
+            }
+            setStored(data);
+            renderRecentList();
+        }
+
+        function renderRecentList() {
+            var data = getStored();
+            var ids = Object.keys(data.sessions || {});
+            if (ids.length === 0) {
+                document.getElementById('recent-sessions').innerHTML = '';
+                return;
+            }
+            ids.sort(function(a, b) {
+                var tA = (data.sessions[a].updatedAt || data.sessions[a].createdAt) || '';
+                var tB = (data.sessions[b].updatedAt || data.sessions[b].createdAt) || '';
+                return tB.localeCompare(tA);
+            });
+            var html = '<span class="text-gray-500">Recent:</span> ';
+            for (var i = 0; i < Math.min(ids.length, 10); i++) {
+                var sid = ids[i];
+                var s = data.sessions[sid];
+                var label = (s.title || 'Conversation').slice(0, 30);
+                if ((s.title || '').length > 30) label += '…';
+                html += '<button type="button" class="session-open px-2 py-1 rounded hover:bg-gray-200" data-session-id="' + escapeHtml(sid) + '">' + escapeHtml(label) + '</button>';
+            }
+            document.getElementById('recent-sessions').innerHTML = html;
+            document.querySelectorAll('#recent-sessions .session-open').forEach(function(btn) {
+                btn.addEventListener('click', function() {
+                    var id = btn.getAttribute('data-session-id');
+                    var data = getStored();
+                    if (data.sessions[id]) {
+                        data.currentId = id;
+                        setStored(data);
+                        var messages = decodeMessages(data.sessions[id].messages_encoded);
+                        var coachLang = document.body.dataset.coachLang || 'simplified';
+                        renderConversation(messages, coachLang);
+                    }
+                });
+            });
+        }
+
         document.body.dataset.coachLang = 'simplified';
         document.querySelectorAll('.tab').forEach(function(btn) {
             btn.addEventListener('click', function() {
@@ -62,10 +198,31 @@
                 if (panel) panel.classList.add('active');
             });
         });
+
+        document.getElementById('btn-new-session').addEventListener('click', function() {
+            var container = document.getElementById('conversation');
+            var initialEncoded = container && container.getAttribute('data-initial-messages');
+            if (!initialEncoded) return;
+            var messages = decodeMessages(initialEncoded);
+            if (messages.length === 0) return;
+            var newId = crypto.randomUUID && crypto.randomUUID() || 'id-' + Date.now();
+            var data = getStored();
+            data.currentId = newId;
+            data.sessions[newId] = { messages_encoded: initialEncoded, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), title: '' };
+            setStored(data);
+            var coachLang = document.body.dataset.coachLang || 'simplified';
+            renderConversation(messages, coachLang);
+            renderRecentList();
+        });
+
         document.body.addEventListener('htmx:afterSwap', function(evt) {
             if (evt.detail && evt.detail.target && evt.detail.target.id === 'conversation') {
                 var el = document.getElementById('coach_lang_input');
                 if (el) el.value = document.body.dataset.coachLang || 'simplified';
+                var encEl = document.getElementById('messages_encoded_input');
+                if (encEl && encEl.value) {
+                    saveToStore(encEl.value, false);
+                }
             }
         });
 
@@ -83,6 +240,25 @@
                 });
             });
         });
+
+        (function restoreOnLoad() {
+            try {
+                var data = getStored();
+                var id = data.currentId;
+                if (id && data.sessions && data.sessions[id]) {
+                    var messages = decodeMessages(data.sessions[id].messages_encoded);
+                    if (messages.length > 0) {
+                        var coachLang = document.body.dataset.coachLang || 'simplified';
+                        renderConversation(messages, coachLang);
+                        renderRecentList();
+                        return;
+                    }
+                }
+                renderRecentList();
+            } catch (e) {
+                renderRecentList();
+            }
+        })();
     </script>
 </body>
 </html>

--- a/apps/socratic/templates/partials/thread_and_form.html
+++ b/apps/socratic/templates/partials/thread_and_form.html
@@ -1,0 +1,39 @@
+<div class="flex flex-col flex-1 min-h-0">
+    <div class="flex-1 overflow-auto pb-4">
+        {% for msg in messages %}
+        <div class="mb-4 {% if msg.role == 'assistant' %}bg-blue-50 border-l-4 border-blue-400 pl-4 py-2 rounded-r{% else %}bg-gray-100 pl-4 py-2 rounded{% endif %}">
+            <p class="text-xs font-medium text-gray-500 mb-1">{% if msg.role == 'assistant' %}Coach{% else %}You{% endif %}</p>
+            <p class="whitespace-pre-wrap">{{ msg.content }}</p>
+        </div>
+        {% endfor %}
+    </div>
+    <div class="shrink-0 border-t border-gray-200 bg-gray-50 pt-4 pb-2">
+        <form
+            hx-post="/reply"
+            hx-target="#conversation"
+            hx-swap="innerHTML"
+            hx-indicator="#form-spinner"
+        >
+            <input type="hidden" name="messages_encoded" value="{{ messages_encoded }}">
+            <input type="hidden" name="coach_lang" id="coach_lang_input" value="simplified">
+            <label for="user_message" class="block text-sm font-medium text-gray-700 mb-1">Your response</label>
+            <textarea
+                id="user_message"
+                name="user_message"
+                rows="3"
+                class="w-full border border-gray-300 rounded-md px-3 py-2 text-gray-900 placeholder-gray-500 focus:ring-1 focus:ring-blue-500 focus:border-blue-500 bg-white"
+                placeholder="Type your thoughts..."
+                required
+            ></textarea>
+            <div class="mt-2 flex items-center gap-2">
+                <button
+                    type="submit"
+                    class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                >
+                    Send
+                </button>
+                <span id="form-spinner" class="htmx-indicator text-sm text-gray-500">Thinking...</span>
+            </div>
+        </form>
+    </div>
+</div>

--- a/apps/socratic/templates/partials/thread_and_form.html
+++ b/apps/socratic/templates/partials/thread_and_form.html
@@ -14,7 +14,7 @@
             hx-swap="innerHTML"
             hx-indicator="#form-spinner"
         >
-            <input type="hidden" name="messages_encoded" value="{{ messages_encoded }}">
+            <input type="hidden" name="messages_encoded" id="messages_encoded_input" value="{{ messages_encoded }}">
             <input type="hidden" name="coach_lang" id="coach_lang_input" value="simplified">
             <label for="user_message" class="block text-sm font-medium text-gray-700 mb-1">Your response</label>
             <textarea

--- a/apps/socratic/verse_parser.py
+++ b/apps/socratic/verse_parser.py
@@ -1,0 +1,52 @@
+"""Parse verse references from coach reply for passage highlighting."""
+
+import re
+
+# Verse range for this passage (Luke 7:36-50)
+VERSE_MIN = 36
+VERSE_MAX = 50
+
+
+def parse_verse_ranges(text: str) -> list[int]:
+    """
+    Extract verse numbers from text (e.g. "verses 38-42" or "v. 44-48").
+    Returns a unique, sorted list of verse numbers in [VERSE_MIN, VERSE_MAX].
+    """
+    if not text or not text.strip():
+        return []
+
+    numbers: set[int] = set()
+
+    # Ranges: "verses 38-42", "verse 38‑42" (incl. Unicode dash U+2011), "v. 44-48", "38-42"
+    range_pattern = re.compile(
+        r"(?:verses?|v\.?|vv\.?)\s*(\d+)\s*[-–—\u2011]\s*(\d+)|(\d+)\s*[-–—\u2011]\s*(\d+)",
+        re.IGNORECASE,
+    )
+    for m in range_pattern.finditer(text):
+        if m.group(1) is not None:
+            start, end = int(m.group(1)), int(m.group(2))
+        else:
+            start, end = int(m.group(3)), int(m.group(4))
+        for n in range(start, end + 1):
+            if VERSE_MIN <= n <= VERSE_MAX:
+                numbers.add(n)
+
+    # Ranges with Chinese 节: "47-49节", "47－49节"
+    range_zh_pattern = re.compile(r"(\d+)\s*[-–—\u2011\u2013]\s*(\d+)\s*节")
+    for m in range_zh_pattern.finditer(text):
+        start, end = int(m.group(1)), int(m.group(2))
+        for n in range(start, end + 1):
+            if VERSE_MIN <= n <= VERSE_MAX:
+                numbers.add(n)
+
+    # Singles: "verse 47", "v. 47", "v47", "42节" (Chinese)
+    single_pattern = re.compile(
+        r"(?:verses?\s+)?v\.?\s*(\d+)\b|verse\s+(\d+)\b|(\d+)\s*节",
+        re.IGNORECASE,
+    )
+    for m in single_pattern.finditer(text):
+        n = int(m.group(1) or m.group(2) or m.group(3))
+        if VERSE_MIN <= n <= VERSE_MAX:
+            numbers.add(n)
+
+    return sorted(numbers)

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -62,6 +62,34 @@ body {
   font-size: 1em;  /* Adjust to match the new base size */
 }
 
+/* Prevent horizontal overflow – allow content to wrap within viewport */
+article.typography,
+.md-typeset {
+  min-width: 0;
+  max-width: 100%;
+}
+
+@media (max-width: 600px) {
+  /* Force content to stay within viewport so cards and text wrap instead of clipping */
+  body {
+    overflow-x: hidden;
+  }
+  .md-main,
+  .md-main__inner,
+  article.typography,
+  .md-typeset,
+  .expandable-cards,
+  .expandable-card {
+    max-width: 100vw;
+    box-sizing: border-box;
+  }
+  /* Card body: constrain width so text wraps; if it still overflows, allow horizontal scroll */
+  .expandable-card__body {
+    max-width: 100vw;
+    box-sizing: border-box;
+  }
+}
+
 /* Adjust other elements as needed */
 .md-typeset h1 {
   font-size: 2em;
@@ -245,14 +273,22 @@ body {
         margin: 1.25rem 0;
     }
 
+    .expandable-card {
+        max-width: 100vw;
+    }
+
     .expandable-card__header {
         padding: 0.9rem 1rem;
         min-height: 3.25rem;
     }
 
+    /* Expand to fit + allow horizontal scroll if content still overflows (full text visible) */
     .expandable-card.is-open .expandable-card__body {
         padding: 0.9rem 1rem 1rem;
         padding-left: calc(1rem + 1.75rem + 0.5rem);
+        overflow-x: auto;
+        overflow-y: visible;
+        -webkit-overflow-scrolling: touch;
     }
 
     .expandable-card__action {

--- a/pixi.lock
+++ b/pixi.lock
@@ -4719,7 +4719,7 @@ packages:
 - pypi: ./
   name: sgbs-training
   version: 0.1.0
-  sha256: e0218958876cfd963697e2f7ed4a7cadf62f91c49a7a4374783c43841d2a3dff
+  sha256: 8f30a28cb37160a18b4567d0a46bf5a3af104e98d91555381cc9ed157cb79027
   requires_dist:
   - mkdocs-shadcn>=0.4.2,<0.10
   requires_python: '>=3.11'

--- a/pixi.lock
+++ b/pixi.lock
@@ -11,6 +11,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.5-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
@@ -30,13 +31,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.0-py312h68727a3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-43.0.1-py312hda17c39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.114.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
@@ -48,14 +52,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.65.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.2.1-py310hb823017_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jiter-0.13.0-py312h0ccc70a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
@@ -87,6 +96,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litellm-1.73.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h66e93f0_1.conda
@@ -96,8 +106,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.1-py312h58c1407_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.2-py312h1d6d2e6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/panel-1.4.5-pyhd8ed1ab_0.conda
@@ -120,7 +131,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.5-h2ad013b_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.12-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.18-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.2-pyhd8ed1ab_0.conda
@@ -128,15 +140,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.1.15-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py312hd04cf1f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.5-pyhd8ed1ab_0.conda
@@ -148,7 +165,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.30.6-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.29.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
@@ -195,12 +212,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.0-py312h6142ec9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-43.0.1-py312h3ddc590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.113.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
@@ -216,16 +235,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.31.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.4.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jiter-0.13.0-py312h232e7c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-23_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-23_osxarm64_openblas.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h3ed4263_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-h55c6f16_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.21-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
@@ -242,6 +265,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.16-hc9fafa5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litellm-1.73.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
@@ -252,6 +276,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.1-py312h801f5e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
@@ -276,7 +301,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.5-h30c5eda_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.9-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.18-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
@@ -284,15 +309,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyviz_comms-3.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.1.15-py312h2bbb03f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py312h6ef9ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiktoken-0.12.0-py312hab2ecbf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tokenizers-0.22.2-py312hab2ecbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.12.5-pyhd8ed1ab_0.conda
@@ -304,7 +334,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.30.6-py312h81bd7bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.29.0-py312h81bd7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
@@ -341,6 +371,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.6-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.3.1-pyhd8ed1ab_0.tar.bz2
@@ -362,8 +393,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.7-unix_pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.0-py312h68727a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-43.0.1-py312hda17c39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
@@ -371,6 +404,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.115.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.4.1-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
@@ -383,16 +417,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/googleapis-common-protos-1.65.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.2.1-py310hb823017_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.27.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jiter-0.13.0-py312h0ccc70a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
@@ -424,6 +463,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litellm-1.73.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h66e93f0_1.conda
@@ -439,8 +479,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.1-py312h58c1407_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/paginate-0.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_1.conda
@@ -473,7 +514,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.5-h2ad013b_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.11-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.12-hd8ed1ab_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.18-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
@@ -482,9 +524,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.9.11-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
@@ -492,7 +536,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py312hd04cf1f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
@@ -505,7 +551,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.30.6-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.29.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-5.0.2-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
@@ -545,6 +591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.0-py312h6142ec9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-43.0.1-py312h3ddc590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.2.0-hd8ed1ab_0.conda
@@ -552,6 +599,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.115.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.4.1-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2024.9.0-pyhff2d567_0.conda
@@ -568,12 +616,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httplib2-0.22.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.27.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.31.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.10-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.5.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-8.27.0-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jiter-0.13.0-py312h232e7c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.2-cxx17_h00cdb27_1.conda
@@ -596,6 +648,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/linkify-it-py-2.0.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/litellm-1.73.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-3.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
@@ -612,6 +665,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.1-py312h801f5e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/oauth2client-4.1.3-py_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-24.1-pyhd8ed1ab_0.conda
@@ -646,7 +700,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.5-h30c5eda_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.11-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.18-pyhff2d567_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2024.1-pyhd8ed1ab_0.conda
@@ -655,9 +709,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyyaml-env-tag-0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2024.9.11-py312h024a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-13.8.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py312h6ef9ec0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-75.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_0.conda
@@ -665,7 +721,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/starlette-0.38.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiktoken-0.12.0-py312hab2ecbf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tokenizers-0.22.2-py312hab2ecbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py312h024a12e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.66.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_0.conda
@@ -678,7 +736,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-1.0.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uritemplate-4.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.30.6-py312h81bd7bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.29.0-py312h81bd7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchdog-5.0.2-py312h024a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
@@ -858,6 +916,17 @@ packages:
   purls: []
   size: 23621
   timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
+  sha256: a3967b937b9abf0f2a99f3173fa4630293979bd1644709d89580e7c62a544661
+  md5: aaa2a381ccc56eac91d63b6c1240312f
+  depends:
+  - cpython
+  - python-gil
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8191
+  timestamp: 1744137672556
 - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.4.0-pyhd8ed1ab_0.conda
   sha256: 5d318408a7ad62c1dbff90060795287f1fd3bdbec13b733bc82f1fadb2c9244e
   md5: 0482cd2217e27b3ce47676d570ac3d45
@@ -1342,6 +1411,17 @@ packages:
   - pkg:pypi/contourpy?source=hash-mapping
   size: 250774
   timestamp: 1727293812329
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_2.conda
+  noarch: generic
+  sha256: ccb90d95bac9f1f4f6629a4addb44d36433e4ad1fe4ac87a864f90ff305dbf6d
+  md5: ef3e093ecfd4533eee992cdaa155b47e
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi * *_cp312
+  license: Python-2.0
+  purls: []
+  size: 46644
+  timestamp: 1769471040321
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-43.0.1-py312hda17c39_0.conda
   sha256: 691c9491da9e730b8b4f6903e05a05530a6699aa73dc483244448fed97348899
   md5: 1b673277378cb4c80a061a4c6f453b6d
@@ -1389,6 +1469,17 @@ packages:
   - pkg:pypi/decorator?source=hash-mapping
   size: 12072
   timestamp: 1641555714315
+- conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.9.0-pyhd8ed1ab_1.conda
+  sha256: 5603c7d0321963bb9b4030eadabc3fd7ca6103a38475b4e0ed13ed6d97c86f4e
+  md5: 0a2014fd9860f8b1eaa0b1f3d3771a08
+  depends:
+  - python >=3.9
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/distro?source=hash-mapping
+  size: 41773
+  timestamp: 1734729953882
 - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.6.1-pyhd8ed1ab_1.conda
   sha256: 0d52c878553e569bccfbd96472c1659fb873bc05e95911b457d35982827626fe
   md5: 936e6aadb75534384d11d982fab74b61
@@ -1524,6 +1615,16 @@ packages:
   - pkg:pypi/fastapi-cli?source=hash-mapping
   size: 14405
   timestamp: 1722597753588
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
+  sha256: 8b90dc21f00167a7e58abb5141a140bdb31a7c5734fe1361b5f98f4a4183fd32
+  md5: 2cfaaccf085c133a477f0a7a8657afe9
+  depends:
+  - python >=3.10
+  license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=hash-mapping
+  size: 18661
+  timestamp: 1768022315929
 - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
   md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
@@ -1809,6 +1910,25 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 46754
   timestamp: 1634280590080
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hf-xet-1.2.1-py310hb823017_0.conda
+  noarch: python
+  sha256: 11b840645c4d321d2b33c0e4cf8a1132bd01d1ccd8e019135c01fab7d4b96ca3
+  md5: 33bd9525f97a50dc414892cba8996b51
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  - openssl >=3.5.4,<4.0a0
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/hf-xet?source=hash-mapping
+  size: 2728965
+  timestamp: 1763772649407
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
   sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
   md5: 914d6646c4dbb1fd3ff539830a12fd71
@@ -1864,6 +1984,47 @@ packages:
   - pkg:pypi/httpx?source=hash-mapping
   size: 65085
   timestamp: 1724778453275
+- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-0.31.4-pyhd8ed1ab_0.conda
+  sha256: c472d3f3607a313e75ee45501455b69d1124ac9f00b2bdb4983048da19c6d375
+  md5: d92d502ff13c190010694d64375959b9
+  depends:
+  - filelock
+  - fsspec >=2023.5.0
+  - packaging >=20.9
+  - python >=3.9
+  - pyyaml >=5.1
+  - requests
+  - tqdm >=4.42.1
+  - typing-extensions >=3.7.4.3
+  - typing_extensions >=3.7.4.3
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/huggingface-hub?source=hash-mapping
+  size: 302452
+  timestamp: 1747670941134
+- conda: https://conda.anaconda.org/conda-forge/noarch/huggingface_hub-1.4.1-pyhd8ed1ab_0.conda
+  sha256: 53de5e4ffe099c0633130c9ddf16c7466441ad799da34c8cb8cdf0a395faedb7
+  md5: 3383f114a8c3dde43619c2d36742e626
+  depends:
+  - filelock
+  - fsspec >=2023.5.0
+  - hf-xet >=1.2.0,<2.0.0
+  - httpx >=0.23.0,<1
+  - packaging >=20.9
+  - python >=3.10
+  - pyyaml >=5.1
+  - requests
+  - shellingham
+  - tqdm >=4.42.1
+  - typer-slim
+  - typing-extensions >=3.7.4.3
+  - typing_extensions >=4.1.0
+  license: Apache-2.0
+  purls:
+  - pkg:pypi/huggingface-hub?source=compressed-mapping
+  size: 343630
+  timestamp: 1770381398456
 - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
   sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
   md5: 9f765cbfab6870c8435b9eefecd7a1f4
@@ -1978,6 +2139,67 @@ packages:
   - pkg:pypi/jinja2?source=hash-mapping
   size: 111565
   timestamp: 1715127275924
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jiter-0.13.0-py312h0ccc70a_0.conda
+  sha256: 82c24124cecbd997550b7e5d9598d43e9c86d7e4266b11c8a98e05c64ee05f89
+  md5: 1bc837710f8bba29c214d0852ee81fdc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jiter?source=hash-mapping
+  size: 308006
+  timestamp: 1770047930797
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/jiter-0.13.0-py312h232e7c1_0.conda
+  sha256: f21aed245e23b4f16aea339daeeaa87beff4f93846b088336688547c9bd592e8
+  md5: 44c1297f9d8223886fdce3fb177d3d57
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jiter?source=hash-mapping
+  size: 266757
+  timestamp: 1770048381048
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.26.0-pyhcf101f3_0.conda
+  sha256: db973a37d75db8e19b5f44bbbdaead0c68dde745407f281e2a7fe4db74ec51d7
+  md5: ada41c863af263cc4c5fcbaff7c3e4dc
+  depends:
+  - attrs >=22.2.0
+  - jsonschema-specifications >=2023.3.6
+  - python >=3.10
+  - referencing >=0.28.4
+  - rpds-py >=0.25.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jsonschema?source=compressed-mapping
+  size: 82356
+  timestamp: 1767839954256
+- conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
+  sha256: 0a4f3b132f0faca10c89fdf3b60e15abb62ded6fa80aebfc007d05965192aa04
+  md5: 439cd0f567d697b20a8f45cb70a1005a
+  depends:
+  - python >=3.10
+  - referencing >=0.31.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/jsonschema-specifications?source=hash-mapping
+  size: 19236
+  timestamp: 1757335715225
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
   sha256: 5c878d104b461b7ef922abe6320711c0d01772f4cd55de18b674f88547870041
   md5: 51bb7010fc86f70eee639b4bb7a894f5
@@ -2209,6 +2431,16 @@ packages:
   purls: []
   size: 520766
   timestamp: 1726782571130
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-h55c6f16_2.conda
+  sha256: 5fbeb2fc2673f0455af6079abf93faaf27f11a92574ad51565fa1ecac9a4e2aa
+  md5: 4cb5878bdb9ebfa65b7cdff5445087c5
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 570068
+  timestamp: 1770238262922
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.21-h4bc722e_0.conda
   sha256: 728c24ce835700bfdfdf106bf04233fdb040a61ca4ecfd3f41b46fa90cd4f971
   md5: 36ce76665bf67f5aac36be7a0d21b7f3
@@ -2761,6 +2993,46 @@ packages:
   - pkg:pypi/linkify-it-py?source=hash-mapping
   size: 24035
   timestamp: 1707129321841
+- conda: https://conda.anaconda.org/conda-forge/noarch/litellm-1.73.6-pyhd8ed1ab_0.conda
+  sha256: 9e00f1448f2e32551e9856e54e23f5d4520b84495253094715ee00af14358e06
+  md5: b680360f49eca11de39da0c28260335d
+  depends:
+  - aiohttp >=3.10
+  - click
+  - httpx >=0.23.0
+  - importlib-metadata >=6.8.0
+  - jinja2 >=3.1.2,<4.0.0
+  - jsonschema >=4.22.0,<5.0.0
+  - openai >=1.68.2
+  - pydantic >=2.0.0,<3.0.0
+  - python >=3.9
+  - python-dotenv >=0.2.0
+  - tiktoken >=0.7.0
+  - tokenizers
+  constrains:
+  - uvloop >=0.21.0,<0.22.0
+  - google-cloud-kms >=2.21.3,<3.0.0
+  - resend >=0.8.0,<0.9.0
+  - apscheduler >=3.10.4,<4.0.0
+  - orjson >=3.9.7,<4.0.0
+  - python-multipart >=0.0.18,<0.0.19
+  - gunicorn >=22.0.0,<23.0.0
+  - fastapi >=0.111.5,<1.0.0
+  - azure-identity >=1.15.0,<2.0.0
+  - prisma >=0.11.0,<0.12.0
+  - uvicorn >=0.29.0,<0.30.0
+  - cryptography >=43.0.1,<44.0.0
+  - fastapi-sso >=0.16.0,<0.17.0
+  - pynacl >=1.5.0,<2.0.0
+  - pyyaml >=6.0.1,<7.0.0
+  - azure-keyvault-secrets >=4.8.0,<5.0.0
+  - pyjwt >=2.8.0,<3.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/litellm?source=hash-mapping
+  size: 6394494
+  timestamp: 1751152584221
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.8-hde57baf_1.conda
   sha256: 7a76e2932ac77e6314bfa1c4ff83f617c8260313bfed1b8401b508ed3e9d70ba
   md5: fe89757e3cd14bb1c6ebd68dac591363
@@ -3174,6 +3446,26 @@ packages:
   - pkg:pypi/oauth2client?source=hash-mapping
   size: 67499
   timestamp: 1549161773242
+- conda: https://conda.anaconda.org/conda-forge/noarch/openai-2.17.0-pyhd8ed1ab_0.conda
+  sha256: 2aba0a3fc4f3c2e310862fcb5e9b63c032335bc22b749143e69b6efc36d8f9b3
+  md5: bba2580283802360dcf5af0a63bad749
+  depends:
+  - anyio >=3.5.0,<5
+  - distro >=1.7.0,<2
+  - httpx >=0.23.0,<1
+  - jiter >=0.10.0,<1
+  - pydantic >=1.9.0,<3
+  - python >=3.10
+  - sniffio
+  - tqdm >4
+  - typing-extensions >=4.11,<5
+  - typing_extensions >=4.11,<5
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/openai?source=hash-mapping
+  size: 390623
+  timestamp: 1770323855231
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
   sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
   md5: 7f2e286780f072ed750df46dc2631138
@@ -3213,6 +3505,18 @@ packages:
   purls: []
   size: 2891789
   timestamp: 1725410790053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+  sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
+  md5: f61eb8cd60ff9057122a3d338b99c00f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3164551
+  timestamp: 1769555830639
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
   sha256: 940fa01c4dc6152158fe8943e05e55a1544cab639df0994e3b35937839e4f4d1
   md5: 1773ebccdc13ec603356e8ff1db9e958
@@ -4033,28 +4337,27 @@ packages:
   - pkg:pypi/python-dotenv?source=hash-mapping
   size: 24278
   timestamp: 1706018281544
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.11-pyhff2d567_0.conda
-  sha256: 73ef078543dad5750e67be2b351e1282ec313b7c861debbe4aa1486172756140
-  md5: d5c8a304491dab10872722cd8ef91fa8
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.12-hd8ed1ab_2.conda
+  sha256: 3307c01627ae45524dfbdb149f7801818608c9c49d88ac89632dff32e149057f
+  md5: d41b6b394546ee6e1c423e28a581fc71
   depends:
-  - python >=3.8
+  - cpython 3.12.12.*
+  - python_abi * *_cp312
+  license: Python-2.0
+  purls: []
+  size: 46618
+  timestamp: 1769471082980
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.18-pyhff2d567_1.conda
+  sha256: 464e546b789b8e881e1dc6b4995a11007d1e7c3ef2a533b9fb970146e85f7af8
+  md5: 8057e4cf29236ea2094cc20fe9ef451e
+  depends:
+  - python >=3.9
   license: Apache-2.0
   license_family: Apache
   purls:
   - pkg:pypi/python-multipart?source=hash-mapping
-  size: 26544
-  timestamp: 1727538548256
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-multipart-0.0.9-pyhd8ed1ab_0.conda
-  sha256: 026467128031bd667c4a32555ae07e922d5caed257e4815c44e7338887bbd56a
-  md5: 0eef653965f0fed2013924d08089f371
-  depends:
-  - python >=3.7
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/python-multipart?source=hash-mapping
-  size: 26439
-  timestamp: 1707760278735
+  size: 27683
+  timestamp: 1732988029649
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
   sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
   md5: 98206ea9954216ee7540f0c773f2104d
@@ -4217,6 +4520,21 @@ packages:
   purls: []
   size: 250351
   timestamp: 1679532511311
+- conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.37.0-pyhcf101f3_0.conda
+  sha256: 0577eedfb347ff94d0f2fa6c052c502989b028216996b45c7f21236f25864414
+  md5: 870293df500ca7e18bedefa5838a22ab
+  depends:
+  - attrs >=22.2.0
+  - python >=3.10
+  - rpds-py >=0.7.0
+  - typing_extensions >=4.4.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/referencing?source=hash-mapping
+  size: 51788
+  timestamp: 1760379115194
 - conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2024.9.11-py312h66e93f0_0.conda
   sha256: d841a27a17a8dc1a39b4b00145fd9a27a2832d838c18fbb8ba48f5bc63a02d6d
   md5: f998667df44480bb9a365998290d8c93
@@ -4231,6 +4549,20 @@ packages:
   - pkg:pypi/regex?source=hash-mapping
   size: 405100
   timestamp: 1726095738310
+- conda: https://conda.anaconda.org/conda-forge/linux-64/regex-2026.1.15-py312h4c3975b_0.conda
+  sha256: 385ed5c0d79aefaf2b23d65a1274392bc64203dcbd10ed6e850d4e4c238977f9
+  md5: 1e502ae660e9aead08a90b533161daaf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0 AND CNRI-Python
+  license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=hash-mapping
+  size: 412393
+  timestamp: 1768558713716
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2024.7.24-py312h024a12e_1.conda
   sha256: fbccfe41667b34e9c49575542899fe75554a2cdede84c52dfe60a587b4302c9d
   md5: e5185a1c86de3b4a4d90c9d8d8ded3d8
@@ -4259,6 +4591,20 @@ packages:
   - pkg:pypi/regex?source=hash-mapping
   size: 366013
   timestamp: 1726095775313
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/regex-2026.1.15-py312h2bbb03f_0.conda
+  sha256: 2fc2df10e4213461d82f6b6198b1ad695dbd312867ee9babcf8f67d35b213c6c
+  md5: 98867cdc9154076eaffd7e674f3e7f02
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: Apache-2.0 AND CNRI-Python
+  license_family: PSF
+  purls:
+  - pkg:pypi/regex?source=hash-mapping
+  size: 374525
+  timestamp: 1768559133281
 - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.3-pyhd8ed1ab_0.conda
   sha256: 5845ffe82a6fa4d437a2eae1e32a1ad308d7ad349f61e337c0a890fe04c513cc
   md5: 5ede4753180c7a550a443c430dc8ab52
@@ -4304,6 +4650,38 @@ packages:
   - pkg:pypi/rich?source=hash-mapping
   size: 185358
   timestamp: 1726066139954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
+  sha256: 62f46e85caaba30b459da7dfcf3e5488ca24fd11675c33ce4367163ab191a42c
+  md5: 3ffc5a3572db8751c2f15bacf6a0e937
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rpds-py?source=hash-mapping
+  size: 383750
+  timestamp: 1764543174231
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.30.0-py312h6ef9ec0_0.conda
+  sha256: ea06f6f66b1bea97244c36fd2788ccd92fd1fb06eae98e469dd95ee80831b057
+  md5: a7cfbbdeb93bb9a3f249bc4c3569cd4c
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.12.* *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rpds-py?source=hash-mapping
+  size: 358853
+  timestamp: 1764543161524
 - conda: https://conda.anaconda.org/conda-forge/noarch/rsa-4.9-pyhd8ed1ab_0.tar.bz2
   sha256: 23214cdc15a41d14136754857fd9cd46ca3c55a7e751da3b3a48c673f0ee2a57
   md5: 03bf410858b2cefc267316408a77c436
@@ -4341,7 +4719,7 @@ packages:
 - pypi: ./
   name: sgbs-training
   version: 0.1.0
-  sha256: 7b0a3a330453b60c92c45b30fddc83ac7b3040d38edb89aa3adb82c9834b7530
+  sha256: e0218958876cfd963697e2f7ed4a7cadf62f91c49a7a4374783c43841d2a3dff
   requires_dist:
   - mkdocs-shadcn>=0.4.2,<0.10
   requires_python: '>=3.11'
@@ -4436,6 +4814,44 @@ packages:
   - pkg:pypi/starlette?source=hash-mapping
   size: 57309
   timestamp: 1727103126382
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tiktoken-0.12.0-py312hd04cf1f_3.conda
+  sha256: 1abd394ed7a131e63acd8e1863ee4a6d9ec44681137d80513736bbb95f3bbc8f
+  md5: 81107f76e8567fc071ec7ebf4de86f92
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - regex >=2022.1.18
+  - requests >=2.26.0
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tiktoken?source=hash-mapping
+  size: 936841
+  timestamp: 1764028290979
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiktoken-0.12.0-py312hab2ecbf_3.conda
+  sha256: cceee6fc76a0cc45f7d6682ce3500624de719e9d8286dd03f5896339c56fbd9a
+  md5: 00cdd928ac2745c5e71c50a15743dd32
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - regex >=2022.1.18
+  - requests >=2.26.0
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tiktoken?source=hash-mapping
+  size: 817801
+  timestamp: 1764028925191
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
   sha256: e0569c9caa68bf476bead1bed3d79650bb080b532c64a4af7d8ca286c08dea4e
   md5: d453b98d9c83e71da0741bb0ff4d76bc
@@ -4457,6 +4873,43 @@ packages:
   purls: []
   size: 3145523
   timestamp: 1699202432999
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tokenizers-0.22.2-py312hf875000_0.conda
+  sha256: ee27a9f82c0c6f91d75deed478516307148cd18e2d7916abce3e0fefba0b5f62
+  md5: f9ee564f977ae6e533537a3f148db136
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - huggingface_hub >=0.16.4,<2.0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.4,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/tokenizers?source=hash-mapping
+  size: 2465644
+  timestamp: 1764695075374
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tokenizers-0.22.2-py312hab2ecbf_0.conda
+  sha256: bbada93f3f947cdda75dd928bff35086d5914a46535e0e6e29261ad7f436b8da
+  md5: e71acda1bd7ea6202437d4b17a027dc3
+  depends:
+  - __osx >=11.0
+  - huggingface_hub >=0.16.4,<2.0
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/tokenizers?source=hash-mapping
+  size: 2207431
+  timestamp: 1764695587965
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py312h66e93f0_1.conda
   sha256: c0c9cc7834e8f43702956afaa5af7b0639c4835c285108a43e6b91687ce53ab8
   md5: af648b62462794649066366af4ecd5b0
@@ -4629,9 +5082,9 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 98076
   timestamp: 1726496531769
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.30.6-py312h7900ff3_0.conda
-  sha256: 85a98c5c92a5cffb238541ad72d5cb4db5e99aff2376fa4d0bf2817d24cfac1f
-  md5: 5c514d198dd2383d05e7d8b4d93e4e16
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.29.0-py312h7900ff3_0.conda
+  sha256: e1f0c882f3b17b6d13f31b214ab87657f53d15cd7b221301104e293044986d8c
+  md5: 5abb5cedead2c9a8d616a1b8e5503be8
   depends:
   - click >=7.0
   - h11 >=0.8
@@ -4641,11 +5094,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/uvicorn?source=hash-mapping
-  size: 132020
-  timestamp: 1723660099723
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.30.6-py312h81bd7bf_0.conda
-  sha256: 8078e14e9f2a4ef3295825018c41e1d8bde1ac936c48dbcd6b5212d1d9fa2140
-  md5: 9059f5a0f4baf1c941a90568e65997e8
+  size: 126964
+  timestamp: 1710932152563
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.29.0-py312h81bd7bf_0.conda
+  sha256: 9590ad1d690406b595a8de487ee0179b83adfb93ea0e4fc1528899bf14f31102
+  md5: 185cc04f463528812c203f79893f007f
   depends:
   - click >=7.0
   - h11 >=0.8
@@ -4656,8 +5109,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/uvicorn?source=hash-mapping
-  size: 133290
-  timestamp: 1723660236813
+  size: 128419
+  timestamp: 1710932439833
 - pypi: https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl
   name: watchdog
   version: 6.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ litellm = ">=1.0.0"
 [tool.pixi.feature.api.tasks]
 app = "uvicorn apps.api:app --host 0.0.0.0 --port 5006 --reload"
 socratic = "uvicorn apps.socratic.app:app --host 0.0.0.0 --port 5007 --reload"
+observation = "uvicorn apps.observation.app:app --host 0.0.0.0 --port 5008 --reload"
 
 [tool.pixi.feature.devtools.dependencies]
 ipython = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,12 @@ panel = "*"
 python-dotenv = "*"
 pyprojroot = "*"
 pydrive2 = ">=1.19.0,<2"
-uvicorn = ">=0.30.6,<0.31"
+uvicorn = "*"
+litellm = ">=1.0.0"
 
 [tool.pixi.feature.api.tasks]
 app = "uvicorn apps.api:app --host 0.0.0.0 --port 5006 --reload"
+socratic = "uvicorn apps.socratic.app:app --host 0.0.0.0 --port 5007 --reload"
 
 [tool.pixi.feature.devtools.dependencies]
 ipython = "*"


### PR DESCRIPTION
Standalone throwaway app to try an AI-led Socratic coach for Bible study prep (Luke 7:36–50).

**LLM:** This experiment uses **Groq `gpt-oss-120b`** via LiteLLM. Set `GROQ_API_KEY` to run.

**Highlights:**
- Passage in 简体 / 繁體 / NIV; coach language follows selected tab
- Verse highlighting when coach cites verses (incl. Chinese "42节", "47-49节")
- Passage text + full chat history sent to the model to avoid wrong verse refs
- Prompt: Socratic only, encouragement, step-back on confusion, suggest other translation when needed

**Run:** `pixi run -e api socratic` (port 5007)

Made with [Cursor](https://cursor.com)