### PR TITLE
Add Traditional/Simplified Chinese toggle button

### DIFF
--- a/docs/javascripts/chinese-toggle.js
+++ b/docs/javascripts/chinese-toggle.js
@@ -1,0 +1,110 @@
+(function () {
+    const STORAGE_KEY = 'chinese-variant';
+    const VARIANT_TRAD = 'zh-tw';
+    const VARIANT_SIMP = 'zh-cn';
+
+    let converter = null;
+    let htmlConverter = null;
+    let currentVariant = VARIANT_TRAD;
+
+    function setLangAttribute() {
+        document.documentElement.setAttribute('lang', currentVariant === VARIANT_TRAD ? 'zh-TW' : 'zh-CN');
+    }
+
+    function loadOpenCC(callback) {
+        if (window.OpenCC) {
+            callback();
+            return;
+        }
+        const script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/opencc-js@1.0.5/dist/umd/full.js';
+        script.onload = callback;
+        document.head.appendChild(script);
+    }
+
+    function initConverter() {
+        converter = window.OpenCC.Converter({ from: 'tw', to: 'cn' });
+    }
+
+    function convertPage() {
+        if (!converter) initConverter();
+        const rootNode = document.documentElement;
+        htmlConverter = window.OpenCC.HTMLConverter(converter, rootNode, 'zh-TW', 'zh-CN');
+        htmlConverter.convert();
+        currentVariant = VARIANT_SIMP;
+        setLangAttribute();
+        updateToggleButton();
+    }
+
+    function restorePage() {
+        if (htmlConverter) {
+            htmlConverter.restore();
+        }
+        currentVariant = VARIANT_TRAD;
+        setLangAttribute();
+        updateToggleButton();
+    }
+
+    function toggleVariant() {
+        if (currentVariant === VARIANT_TRAD) {
+            convertPage();
+            localStorage.setItem(STORAGE_KEY, VARIANT_SIMP);
+        } else {
+            restorePage();
+            localStorage.setItem(STORAGE_KEY, VARIANT_TRAD);
+        }
+    }
+
+    function updateToggleButton() {
+        const btn = document.getElementById('chinese-toggle-btn');
+        if (btn) {
+            btn.textContent = currentVariant === VARIANT_TRAD ? '简' : '繁';
+            btn.setAttribute('aria-label', currentVariant === VARIANT_TRAD ? '切换到简体中文' : '切換到繁體中文');
+            btn.setAttribute('title', currentVariant === VARIANT_TRAD ? '切换到简体中文' : '切換到繁體中文');
+        }
+    }
+
+    function createToggleButton() {
+        const btn = document.createElement('button');
+        btn.id = 'chinese-toggle-btn';
+        btn.className = 'chinese-toggle-btn';
+        btn.textContent = '简';
+        btn.setAttribute('aria-label', '切换到简体中文');
+        btn.setAttribute('title', '切换到简体中文');
+        btn.addEventListener('click', toggleVariant);
+        return btn;
+    }
+
+    function insertToggleButton() {
+        if (document.getElementById('chinese-toggle-btn')) return;
+
+        const header = document.querySelector('header') || document.querySelector('.md-header');
+        if (header) {
+            const btn = createToggleButton();
+            header.appendChild(btn);
+        }
+    }
+
+    function applyStoredPreference() {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored === VARIANT_SIMP) {
+            loadOpenCC(function () {
+                convertPage();
+            });
+        }
+    }
+
+    function init() {
+        setLangAttribute();
+        insertToggleButton();
+        applyStoredPreference();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+
+    document.addEventListener('DOMContentLoaded', applyStoredPreference);
+})();

--- a/docs/javascripts/chinese-toggle.js
+++ b/docs/javascripts/chinese-toggle.js
@@ -47,8 +47,10 @@
 
     function toggleVariant() {
         if (currentVariant === VARIANT_TRAD) {
-            convertPage();
-            localStorage.setItem(STORAGE_KEY, VARIANT_SIMP);
+            loadOpenCC(function () {
+                convertPage();
+                localStorage.setItem(STORAGE_KEY, VARIANT_SIMP);
+            });
         } else {
             restorePage();
             localStorage.setItem(STORAGE_KEY, VARIANT_TRAD);

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -545,3 +545,54 @@ article.typography table tbody tr:hover,
         gap: 1rem;
     }
 }
+
+.chinese-toggle-btn {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    z-index: 1000;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: 1px solid var(--border, rgba(0, 0, 0, 0.12));
+    background: var(--background, #fff);
+    color: var(--foreground, #1a1a1a);
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.chinese-toggle-btn:hover {
+    background: var(--muted, rgba(0, 0, 0, 0.06));
+    transform: scale(1.05);
+}
+
+.chinese-toggle-btn:focus-visible {
+    outline: 2px solid var(--ring, #2563eb);
+    outline-offset: 2px;
+}
+
+.dark .chinese-toggle-btn {
+    background: var(--background, #1a1a1a);
+    color: var(--foreground, #fafafa);
+    border-color: var(--border, rgba(255, 255, 255, 0.12));
+}
+
+.dark .chinese-toggle-btn:hover {
+    background: var(--muted, rgba(255, 255, 255, 0.1));
+}
+
+@media (max-width: 600px) {
+    .chinese-toggle-btn {
+        top: 0.75rem;
+        right: 0.75rem;
+        width: 2.25rem;
+        height: 2.25rem;
+        font-size: 0.9rem;
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ extra_css:
 
 extra_javascript:
   - javascripts/expandable-cards.js
+  - javascripts/chinese-toggle.js
 
 plugins:
   - search


### PR DESCRIPTION
## Summary

- Add client-side Chinese conversion using opencc-js library
- Floating toggle button in top-right corner for switching between Traditional (繁) and Simplified (简) Chinese
- User preference persisted in localStorage
- Dynamically sets `lang` attribute on HTML element for accessibility

## Technical Details

- Uses opencc-js (loaded from CDN) for Traditional → Simplified conversion
- No build process changes required
- Works entirely client-side
- Supports dark mode

## Test Plan

1. Run `pixi run -e website serve`
2. Click the toggle button in top-right corner
3. Verify text converts from Traditional to Simplified Chinese
4. Refresh page and verify preference is remembered
5. Toggle back to Traditional and verify restoration