### PR TITLE
fix(roster-ci): production Convex deploy uses the deploy key's target (no --prod)

### DIFF
--- a/.github/workflows/roster-deploy.yaml
+++ b/.github/workflows/roster-deploy.yaml
@@ -120,7 +120,9 @@ jobs:
 
       - name: Deploy Convex functions (production)
         if: ${{ env.CONVEX_DEPLOY_KEY != '' }}
-        run: npx convex@latest deploy --prod
+        # CONVEX_DEPLOY_KEY must be a PROD deploy key (prod|...); the
+        # deployment target comes from the key itself, so no --prod flag.
+        run: npx convex@latest deploy
         working-directory: apps/roster
         env:
           CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}


### PR DESCRIPTION
## Summary

Follow-up to #123. The production deploy job failed because `npx convex deploy --prod` is not a valid flag when a `CONVEX_DEPLOY_KEY` is configured: the deployment target comes from the key itself (a `prod|...` key deploys to production; a `preview|...` key deploys to a preview deployment). The CLI rejected the flag outright.

```
error: unknown option '--prod'
```

## Fix

`npx convex deploy` with no flag — target determined by the deploy key, per the Convex CLI docs.

## Checklist note for the operator

Confirm the `CONVEX_DEPLOY_KEY` secret is a **production** deploy key (from deployment `abundant-dodo-507`, name starts with `prod|`) AND that the key has **write** access. If it is a preview key, the deploy will silently target the preview deployment instead — regenerate as prod if needed.