### PR TITLE
docs(roster): clarify CI timeline

### DIFF
--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -117,8 +117,8 @@ npx convex deploy     # push functions to prod (confirm the Y/n prompt)
 vercel deploy --prod  # build + ship the frontend
 ```
 
-CI (`.github/workflows/roster.yml`, added 2026-09-05, upgraded to real
-Convex preview deployments 2026-09-05): the Vercel build command runs
+CI (`.github/workflows/roster.yml`, added 2026-09-05; same-day upgrade
+to per-branch Convex preview deployments): the Vercel build command runs
 `npx convex deploy --cmd 'npm run build'` (see `apps/roster/vercel.json`),
 so Convex functions and the frontend always deploy together.
 


### PR DESCRIPTION
Smoke-test PR for the preview pipeline: exercises the per-branch Convex preview deployment + PR comment flow. Carries a trivial README wording fix so the diff is non-empty.