### PR TITLE
chore(roster): slim students schema — createdTime, drop homework columns, harmonize date scalars

### DIFF
--- a/airtable_dump/transform_seed.py
+++ b/airtable_dump/transform_seed.py
@@ -4,8 +4,8 @@
 """Transform the Airtable 学员名单 dump into Convex-ready seed documents.
 
 - Flattens record.fields into top-level keys (Chinese field names preserved).
-- Resolves multipleRecordLinks (主领日期/观察日期 -> 课程日期, 助教 -> 教师)
-  into arrays of display values using the other dumps.
+- Resolves multipleRecordLinks (主领日期/观察日期 -> 课程日期) into
+  arrays of display values using the other dumps.
 - Generalizes the scalar 带领日期/观察的日期 into the leadingSessions/
   observingSessions arrays; homework columns are no longer tracked.
 - Replicates the Missed formula (5 - number of checked 課堂) and verifies it
@@ -23,7 +23,6 @@ LINKS = {
     "主领日期": ("tblQgLBaK0KENUuwT", "主领日期"),
     "观察日期": ("tblQgLBaK0KENUuwT", "观察日期"),
     "功课（提交）": ("tblzkrTts5Fr5kw1l", "功课（提交）"),
-    "助教": ("tblK2NxjToVdVQZuJ", "助教"),
 }
 CLASS_CHECKBOXES = ["課堂（一）", "課堂（二）", "課堂（三）", "課堂（四）", "課堂（五）"]
 
@@ -47,7 +46,6 @@ KEY_MAP = {
     "Missed": "missed",
     "主领日期": "leadingSessions",
     "观察日期": "observingSessions",
-    "助教": "teachingAssistants",
     "书本订购": "bookOrder",
 }
 

--- a/airtable_dump/transform_seed.py
+++ b/airtable_dump/transform_seed.py
@@ -4,10 +4,12 @@
 """Transform the Airtable 学员名单 dump into Convex-ready seed documents.
 
 - Flattens record.fields into top-level keys (Chinese field names preserved).
-- Resolves multipleRecordLinks (主领日期/观察日期 -> 课程日期, 功课（提交） -> 功课,
-  助教 -> 教师) into arrays of display values using the other dumps.
+- Resolves multipleRecordLinks (主领日期/观察日期 -> 课程日期, 助教 -> 教师)
+  into arrays of display values using the other dumps.
+- Generalizes the scalar 带领日期/观察的日期 into the leadingSessions/
+  observingSessions arrays; homework columns are no longer tracked.
 - Replicates the Missed formula (5 - number of checked 課堂) and verifies it
-  against Airtable's stored value; same for 功课提交数目 (count of 功课（提交）).
+  against Airtable's stored value.
 - Writes students_seed.jsonl (one document per line) for `npx convex import`.
 """
 
@@ -34,8 +36,6 @@ KEY_MAP = {
     "受洗時間": "baptismTime",
     "参与训练的季度": "quarter",
     "小组名字": "groupName",
-    "带领日期": "leadingDate",
-    "观察的日期": "observingDate",
     "性別": "gender",
     "帶領查經經驗": "leadingExperience",
     "出席": "present",
@@ -47,10 +47,8 @@ KEY_MAP = {
     "Missed": "missed",
     "主领日期": "leadingSessions",
     "观察日期": "observingSessions",
-    "功课（提交）": "homeworkSubmitted",
     "助教": "teachingAssistants",
     "书本订购": "bookOrder",
-    "功课提交数目": "homeworkCount",
 }
 
 
@@ -90,7 +88,6 @@ def main() -> None:
 
     docs = []
     mismatch_missed = 0
-    mismatch_count = 0
     for rec in students:
         f = rec["fields"]
         doc = {
@@ -101,7 +98,7 @@ def main() -> None:
         # Scalar fields, copied as-is.
         for key in [
             "名字", "團契", "郵箱", "受洗時間", "参与训练的季度", "小组名字",
-            "带领日期", "观察的日期", "性別", "帶領查經經驗", "出席",
+            "性別", "帶領查經經驗", "出席",
             *CLASS_CHECKBOXES, "书本订购",
         ]:
             if key in f:
@@ -115,7 +112,19 @@ def main() -> None:
                 for rid in ids if rid in lookup[ref_table]
             ]
 
-        # Replicate computed fields + verify.
+        # Generalize the scalar 带领日期/观察的日期 into the session
+        # arrays; homework columns are no longer tracked in Convex.
+        for sessions_key, scalar_key in (
+            ("主领日期", "带领日期"),
+            ("观察日期", "观察的日期"),
+        ):
+            scalar = doc.pop(scalar_key, None)
+            if scalar and scalar not in doc[sessions_key]:
+                doc[sessions_key] = [*doc[sessions_key], scalar]
+        doc.pop("功课（提交）", None)
+        doc.pop("功课提交数目", None)
+
+        # Replicate the Missed formula + verify.
         computed_missed = sum(1 for c in CLASS_CHECKBOXES if not f.get(c))
         if "Missed" in f and f["Missed"] != computed_missed:
             mismatch_missed += 1
@@ -124,15 +133,6 @@ def main() -> None:
                 f"computed={computed_missed}"
             )
         doc["Missed"] = computed_missed
-
-        computed_count = len(f.get("功课（提交）", []))
-        if "功课提交数目" in f and f["功课提交数目"] != computed_count:
-            mismatch_count += 1
-            print(
-                f"  功课提交数目 mismatch {rec['id']}: "
-                f"airtable={f['功课提交数目']} computed={computed_count}"
-            )
-        doc["功课提交数目"] = computed_count
 
         docs.append(doc)
 
@@ -144,11 +144,10 @@ def main() -> None:
 
     print(f"wrote {len(docs)} documents -> {out}")
     print(f"Missed formula mismatches: {mismatch_missed}")
-    print(f"功课提交数目 mismatches: {mismatch_count}")
 
     # Quarter distribution (for the 本季度 view sanity check).
     from collections import Counter
-    quarters = Counter(d.get("quarter") for d in docs)
+    quarters = Counter(d.get("参与训练的季度") for d in docs)
     for q, n in sorted(quarters.items(), key=lambda kv: str(kv[0])):
         print(f"  {q}: {n}")
 

--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -89,12 +89,18 @@ is the gate.
 Convex requires ASCII field names, so documents use English keys
 (`name`, `fellowship`, `email`, `baptismTime`, `quarter`, `groupName`,
 `gender`, `leadingExperience`, `present`, `class1`-`class5`, `missed`,
-`homeworkSubmitted`, `homeworkCount`, `photoStorageId`, `source`); the
-UI shows the original Chinese labels. Linked-record fields
+`leadingSessions`, `observingSessions`, `photoStorageId`, `source`);
+the UI shows the original Chinese labels. Linked-record fields
 were resolved to display values at import time (主领日期/观察日期 →
-课程日期, 功课（提交） → 功课, 助教 → 教师). The Airtable `Missed` formula
-(unchecked classes, 1-5) and `功课提交数目` count are replicated at
-write time and verified to match all 284 migrated records.
+课程日期, 助教 → 教师). The Airtable `Missed` formula (unchecked
+classes, 1-5) is replicated at write time and verified to match all
+284 migrated records.
+
+Dropped in the 2026-09-05 cleanup: the homework columns
+(功课（提交）→`homeworkSubmitted`, 功课提交数目→`homeworkCount`) are no
+longer tracked, and the scalar 带领日期/观察的日期 were harmonized into
+the `leadingSessions`/`observingSessions` arrays by
+`migrations:cleanupStudentFields`.
 
 ## Local development
 

--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -89,18 +89,20 @@ is the gate.
 Convex requires ASCII field names, so documents use English keys
 (`name`, `fellowship`, `email`, `baptismTime`, `quarter`, `groupName`,
 `gender`, `leadingExperience`, `present`, `class1`-`class5`, `missed`,
-`leadingSessions`, `observingSessions`, `photoStorageId`, `source`);
-the UI shows the original Chinese labels. Linked-record fields
-were resolved to display values at import time (主领日期/观察日期 →
-课程日期, 助教 → 教师). The Airtable `Missed` formula (unchecked
-classes, 1-5) is replicated at write time and verified to match all
-284 migrated records.
+`leadingSessions`, `observingSessions`, `photoStorageId`); the UI shows
+the original Chinese labels. Linked-record fields were resolved to
+display values at import time (主领日期/观察日期 → 课程日期). The Airtable
+`Missed` formula (unchecked classes, 1-5) is replicated at write time
+and verified to match all 284 migrated records.
 
 Dropped in the 2026-09-05 cleanup: the homework columns
-(功课（提交）→`homeworkSubmitted`, 功课提交数目→`homeworkCount`) are no
-longer tracked, and the scalar 带领日期/观察的日期 were harmonized into
-the `leadingSessions`/`observingSessions` arrays by
-`migrations:cleanupStudentFields`.
+(功课（提交）→`homeworkSubmitted`, 功课提交数目→`homeworkCount`), the
+scalar 带领日期/观察的日期 (harmonized into the
+`leadingSessions`/`observingSessions` arrays), `source`, and
+`teachingAssistants` — all stripped from existing rows by
+`migrations:cleanupStudentFields`. The same migration sets `present`
+to true on every row and backfills `class1`-`class5` = true (with
+`missed` = 0) for rows whose five attendance marks were all blank.
 
 ## Local development
 

--- a/apps/roster/convex/auth.ts
+++ b/apps/roster/convex/auth.ts
@@ -177,11 +177,10 @@ export const verifyRegistrationCode = mutation({
         baptismTime: registration.baptismTime,
         leadingExperience: registration.leadingExperience,
         quarter,
-        present: false,
+        present: true,
         missed: 0,
         createdTime: new Date().toISOString(),
         photoStorageId: registration.photoStorageId,
-        source: "form",
       });
     }
     return {

--- a/apps/roster/convex/auth.ts
+++ b/apps/roster/convex/auth.ts
@@ -179,8 +179,7 @@ export const verifyRegistrationCode = mutation({
         quarter,
         present: false,
         missed: 0,
-        homeworkSubmitted: [],
-        homeworkCount: 0,
+        createdTime: new Date().toISOString(),
         photoStorageId: registration.photoStorageId,
         source: "form",
       });

--- a/apps/roster/convex/demo.ts
+++ b/apps/roster/convex/demo.ts
@@ -54,7 +54,7 @@ export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
         leadingExperience: s.leadingExperience,
         groupName: s.groupName,
         quarter: CURRENT_QUARTER,
-        present: attended >= 4,
+        present: true,
         class1: attended >= 1,
         class2: attended >= 2,
         class3: attended >= 3,
@@ -62,7 +62,6 @@ export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
         class5: attended >= 5,
         missed: 5 - attended,
         createdTime: new Date().toISOString(),
-        source: "preview-demo",
       });
       idByEmail.set(s.email, id);
       studentsAdded++;
@@ -132,7 +131,6 @@ export const resetQuarterData = internalMutation({
       await ctx.db.patch(s._id, {
         groupName: undefined,
         missed: 0,
-        present: undefined,
         class1: undefined,
         class2: undefined,
         class3: undefined,

--- a/apps/roster/convex/demo.ts
+++ b/apps/roster/convex/demo.ts
@@ -61,8 +61,7 @@ export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
         class4: attended >= 4,
         class5: attended >= 5,
         missed: 5 - attended,
-        homeworkSubmitted: [],
-        homeworkCount: attended >= 3 ? 2 : attended,
+        createdTime: new Date().toISOString(),
         source: "preview-demo",
       });
       idByEmail.set(s.email, id);

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -30,9 +30,16 @@ export const dropLegacyClerkIds = internalMutation({
 // 1. Harmonize the legacy scalar dates (leadingDate/observingDate, from
 //    Airtable 带领日期/观察的日期) into the leadingSessions/
 //    observingSessions arrays.
-// 2. Strip the no-longer-relevant homework columns (homeworkSubmitted,
-//    homeworkCount) and the scalar date fields.
-// 3. Backfill createdTime on app-created rows (which never set it) from
+// 2. Strip the fields dropped from the schema: the homework columns
+//    (homeworkSubmitted/homeworkCount), the scalar date fields, the
+//    provenance `source`, and the legacy `teachingAssistants` links.
+// 3. Set `present` to true on every row.
+// 4. Backfill `class1`-`class5` = true for rows whose five attendance
+//    marks are ALL blank (attendance never recorded); rows with any
+//    mark recorded are left untouched. `missed` (the replicated
+//    unchecked-class count) is recomputed to 0 for those rows so the
+//    缺課 column agrees with the all-attended marks.
+// 5. Backfill createdTime on app-created rows (which never set it) from
 //    the system _creationTime; imported Airtable rows keep their true
 //    value.
 // Safe to re-run — every pass no-ops when nothing matches. Run via:
@@ -42,6 +49,8 @@ export const cleanupStudentFields = internalMutation({
     let seen = 0;
     let harmonized = 0;
     let stripped = 0;
+    let presentSet = 0;
+    let classesBackfilled = 0;
     let createdBackfilled = 0;
     for (const s of await ctx.db.query("students").collect()) {
       seen++;
@@ -53,6 +62,8 @@ export const cleanupStudentFields = internalMutation({
         observingDate?: string;
         homeworkSubmitted?: string[];
         homeworkCount?: number;
+        source?: string;
+        teachingAssistants?: string[];
         createdTime?: string;
       };
       const patch: Record<string, unknown> = {};
@@ -80,13 +91,42 @@ export const cleanupStudentFields = internalMutation({
         legacy.leadingDate !== undefined ||
         legacy.observingDate !== undefined ||
         legacy.homeworkSubmitted !== undefined ||
-        legacy.homeworkCount !== undefined
+        legacy.homeworkCount !== undefined ||
+        legacy.source !== undefined ||
+        legacy.teachingAssistants !== undefined
       ) {
         patch.leadingDate = undefined;
         patch.observingDate = undefined;
         patch.homeworkSubmitted = undefined;
         patch.homeworkCount = undefined;
+        patch.source = undefined;
+        patch.teachingAssistants = undefined;
         stripped++;
+      }
+
+      // 出席: true on every row.
+      if (s.present !== true) {
+        patch.present = true;
+        presentSet++;
+      }
+
+      // class1-5: backfill true only when ALL five marks are blank
+      // (attendance never recorded); recompute the replicated missed
+      // count so it agrees with the marks.
+      if (
+        s.class1 === undefined &&
+        s.class2 === undefined &&
+        s.class3 === undefined &&
+        s.class4 === undefined &&
+        s.class5 === undefined
+      ) {
+        patch.class1 = true;
+        patch.class2 = true;
+        patch.class3 = true;
+        patch.class4 = true;
+        patch.class5 = true;
+        patch.missed = 0;
+        classesBackfilled++;
       }
 
       // App-created rows never set createdTime; backfill it from the
@@ -104,6 +144,13 @@ export const cleanupStudentFields = internalMutation({
         if (leading || observing) harmonized++;
       }
     }
-    return { seen, harmonized, stripped, createdBackfilled };
+    return {
+      seen,
+      harmonized,
+      stripped,
+      presentSet,
+      classesBackfilled,
+      createdBackfilled,
+    };
   },
 });

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -25,3 +25,85 @@ export const dropLegacyClerkIds = internalMutation({
     return { seen, removed };
   },
 });
+
+// One-time cleanup (2026-09-05) accompanying the schema slim-down:
+// 1. Harmonize the legacy scalar dates (leadingDate/observingDate, from
+//    Airtable 带领日期/观察的日期) into the leadingSessions/
+//    observingSessions arrays.
+// 2. Strip the no-longer-relevant homework columns (homeworkSubmitted,
+//    homeworkCount) and the scalar date fields.
+// 3. Backfill createdTime on app-created rows (which never set it) from
+//    the system _creationTime; imported Airtable rows keep their true
+//    value.
+// Safe to re-run — every pass no-ops when nothing matches. Run via:
+//   npx convex run migrations:cleanupStudentFields [--prod]
+export const cleanupStudentFields = internalMutation({
+  handler: async (ctx) => {
+    let seen = 0;
+    let harmonized = 0;
+    let stripped = 0;
+    let createdBackfilled = 0;
+    for (const s of await ctx.db.query("students").collect()) {
+      seen++;
+      // Cast needed: these fields are deliberately absent from the
+      // schema, but legacy documents still carry them until this
+      // migration strips them (same pattern as dropLegacyClerkIds).
+      const legacy = s as {
+        leadingDate?: string;
+        observingDate?: string;
+        homeworkSubmitted?: string[];
+        homeworkCount?: number;
+        createdTime?: string;
+      };
+      const patch: Record<string, unknown> = {};
+
+      // Merge the scalar date into the session array (dedupe; sorted
+      // oldest-first when every entry is an ISO date).
+      const merge = (
+        scalar: string | undefined,
+        sessions: string[] | undefined,
+      ): string[] | undefined => {
+        if (!scalar) return undefined;
+        const merged = [...new Set([...(sessions ?? []), scalar])];
+        if (merged.every((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))) {
+          merged.sort();
+        }
+        return merged;
+      };
+      const leading = merge(legacy.leadingDate, s.leadingSessions);
+      if (leading) patch.leadingSessions = leading;
+      const observing = merge(legacy.observingDate, s.observingSessions);
+      if (observing) patch.observingSessions = observing;
+
+      // Unset the fields removed from the schema.
+      if (
+        legacy.leadingDate !== undefined ||
+        legacy.observingDate !== undefined ||
+        legacy.homeworkSubmitted !== undefined ||
+        legacy.homeworkCount !== undefined
+      ) {
+        patch.leadingDate = undefined;
+        patch.observingDate = undefined;
+        patch.homeworkSubmitted = undefined;
+        patch.homeworkCount = undefined;
+        stripped++;
+      }
+
+      // App-created rows never set createdTime; backfill it from the
+      // system creation time so every row carries its true date.
+      if (legacy.createdTime === undefined) {
+        patch.createdTime = new Date(s._creationTime).toISOString();
+        createdBackfilled++;
+      }
+
+      if (Object.keys(patch).length > 0) {
+        await ctx.db.patch(
+          s._id,
+          patch as unknown as Partial<Doc<"students">>,
+        );
+        if (leading || observing) harmonized++;
+      }
+    }
+    return { seen, harmonized, stripped, createdBackfilled };
+  },
+});

--- a/apps/roster/convex/schema.ts
+++ b/apps/roster/convex/schema.ts
@@ -30,13 +30,9 @@ export default defineSchema({
     // now lives on the sessions table.
     leadingSessions: v.optional(v.array(v.string())),
     observingSessions: v.optional(v.array(v.string())),
-    // Legacy from Airtable 助教 links; kept for history.
-    teachingAssistants: v.optional(v.array(v.string())),
     bookOrder: v.optional(v.string()),
     // Optional registration photo (front-camera snap or gallery pick).
     photoStorageId: v.optional(v.id("_storage")),
-    // "airtable" for migrated records, "form" for new registrations.
-    source: v.optional(v.string()),
   })
     .index("by_quarter", ["quarter"])
     .index("by_email", ["email"])

--- a/apps/roster/convex/schema.ts
+++ b/apps/roster/convex/schema.ts
@@ -24,19 +24,15 @@ export default defineSchema({
     class5: v.optional(v.boolean()),
     // Replicated Airtable formula: number of unchecked classes (1-5).
     missed: v.number(),
-    // Legacy Airtable per-student assignment fields. Assignments now live
-    // on the sessions table; these remain only for migrated history.
+    // Legacy per-student assignment history (Airtable 主领日期/观察日期
+    // links plus the older scalar 带领日期/观察的日期, harmonized into
+    // these arrays by migrations:cleanupStudentFields). Assignment truth
+    // now lives on the sessions table.
     leadingSessions: v.optional(v.array(v.string())),
     observingSessions: v.optional(v.array(v.string())),
-    leadingDate: v.optional(v.string()),
-    observingDate: v.optional(v.string()),
-    // Resolved display values (was multipleRecordLinks).
-    homeworkSubmitted: v.array(v.string()),
     // Legacy from Airtable 助教 links; kept for history.
     teachingAssistants: v.optional(v.array(v.string())),
     bookOrder: v.optional(v.string()),
-    // Replicated Airtable count field.
-    homeworkCount: v.number(),
     // Optional registration photo (front-camera snap or gallery pick).
     photoStorageId: v.optional(v.id("_storage")),
     // "airtable" for migrated records, "form" for new registrations.

--- a/apps/roster/convex/students.ts
+++ b/apps/roster/convex/students.ts
@@ -340,14 +340,14 @@ export const registerStudent = mutation({
       baptismTime: args.baptismTime,
       leadingExperience: args.leadingExperience,
       quarter,
-      present: false,
+      // 出席 is true on every row (2026-09-05 cleanup).
+      present: true,
       // Attendance starts unrecorded (0 misses recorded), not 5.
       missed: 0,
       // Airtable-era rows carry createdTime from the dump; new rows
       // stamp it here (ISO-8601, same format).
       createdTime: new Date().toISOString(),
       photoStorageId: args.photoStorageId,
-      source: "form",
     });
     return { status: "created" as const, id };
   },

--- a/apps/roster/convex/students.ts
+++ b/apps/roster/convex/students.ts
@@ -83,16 +83,6 @@ export const observers = query({
   },
 });
 
-// 功课: students with at least one submitted homework.
-export const withHomework = query({
-  handler: async (ctx) => {
-    await requireInstructor(ctx);
-    return (await ctx.db.query("students").collect()).filter(
-      (s) => s.homeworkCount > 0,
-    );
-  },
-});
-
 // Missed: students who missed at least one class.
 export const withMissed = query({
   handler: async (ctx) => {
@@ -353,8 +343,9 @@ export const registerStudent = mutation({
       present: false,
       // Attendance starts unrecorded (0 misses recorded), not 5.
       missed: 0,
-      homeworkSubmitted: [],
-      homeworkCount: 0,
+      // Airtable-era rows carry createdTime from the dump; new rows
+      // stamp it here (ISO-8601, same format).
+      createdTime: new Date().toISOString(),
       photoStorageId: args.photoStorageId,
       source: "form",
     });

--- a/apps/roster/docs/designs/roster-views/LLD.md
+++ b/apps/roster/docs/designs/roster-views/LLD.md
@@ -19,7 +19,6 @@ never reach this surface. The tab opens on 本季度 (current season), not
 | 帶領經驗 | students:withExperience | leadingExperience ≠ 沒帶過 |
 | 主領日期 | students:leaders | derived: leads ≥ 1 session |
 | 觀察日期 | students:observers | derived: observes ≥ 1 session |
-| 功課 | students:withHomework | homeworkCount > 0 |
 | Missed 缺課 | students:withMissed | missed > 0 |
 | 團契/受洗/性別/季度 看板 | students:grouped | grouped by select field |
 

--- a/apps/roster/docs/designs/roster-views/roster-views-EARS.md
+++ b/apps/roster/docs/designs/roster-views/roster-views-EARS.md
@@ -21,8 +21,6 @@
       the sessions table.
 - [x] **ROSTER-GRID-005**: The 觀察日期 view shall show each student who
       observes at least one session, with their observing dates.
-- [x] **ROSTER-GRID-006**: The 功課 view shall show each student with at
-      least one submitted homework and the submission count.
 - [x] **ROSTER-GRID-007**: The 缺課 view shall show the five class marks
       (attended / absent / unrecorded) per student with a legend, and only
       students with missed > 0.

--- a/apps/roster/docs/designs/roster-views/roster-views-EARS.md
+++ b/apps/roster/docs/designs/roster-views/roster-views-EARS.md
@@ -11,7 +11,7 @@
 
 - [x] **ROSTER-GRID-001**: The Master view shall show every student with
       name, fellowship, gender, email, quarter, group, leading
-      experience, missed count, and source.
+      experience, and missed count.
 - [x] **ROSTER-GRID-002**: The 本季度 view shall show only students whose
       quarter equals the current quarter.
 - [x] **ROSTER-GRID-003**: The 帶領經驗 view shall show only students with

--- a/apps/roster/src/Roster.tsx
+++ b/apps/roster/src/Roster.tsx
@@ -13,7 +13,6 @@ const VIEWS = [
   { key: "experience", label: "帶領經驗" },
   { key: "leaders", label: "主領" },
   { key: "observers", label: "觀察" },
-  { key: "homework", label: "功課" },
   { key: "missed", label: "缺課" },
   { key: "k-fellowship", label: "團契" },
   { key: "k-baptism", label: "受洗" },
@@ -60,7 +59,6 @@ export default function Roster() {
         {view === "experience" && "有帶領查經經驗的學員"}
         {view === "leaders" && "曾主領或已排定主領日期的學員"}
         {view === "observers" && "曾觀察或已排定觀察日期的學員"}
-        {view === "homework" && "已提交功課的學員"}
         {view === "missed" && "本季有缺課記錄的學員"}
         {(view === "k-fellowship" ||
           view === "k-baptism" ||
@@ -75,7 +73,6 @@ export default function Roster() {
         {view === "experience" && <ExperienceView />}
         {view === "leaders" && <LeadersView />}
         {view === "observers" && <ObserversView />}
-        {view === "homework" && <HomeworkView />}
         {view === "missed" && <MissedView />}
         {view === "k-fellowship" && <Kanban field="fellowship" label="團契" />}
         {view === "k-baptism" && (
@@ -178,7 +175,7 @@ function ExperienceView() {
         ["名字", (s) => s.name, "serif"],
         ["團契", (s) => s.fellowship ?? ""],
         ["帶領經驗", (s) => s.leadingExperience ?? ""],
-        ["帶領日期", (s) => s.leadingDate ?? "", "margin"],
+        ["帶領日期", (s) => (s.leadingSessions ?? []).join("、"), "margin"],
       ]}
     />
   );
@@ -211,22 +208,6 @@ function ObserversView() {
         ["名字", (s: LeaderRow) => s.name, "serif"],
         ["團契", (s: LeaderRow) => s.fellowship ?? ""],
         ["觀察日期", (s: LeaderRow) => s.dates.join("、"), "margin"],
-      ]}
-    />
-  );
-}
-
-function HomeworkView() {
-  const students = useQuery(api.students.withHomework);
-  const photos = useQuery(api.students.photoUrls);
-  return (
-    <StudentTable
-      students={students}
-      photos={photos}
-      columns={[
-        ["名字", (s) => s.name, "serif"],
-        ["功課（提交）", (s) => s.homeworkSubmitted.join("、")],
-        ["數目", (s) => String(s.homeworkCount), "margin"],
       ]}
     />
   );


### PR DESCRIPTION
## What

Three data/schema cleanups for the roster (round 1) plus three more (round 2):

1. **createdTime on new rows** — all three insert paths (instructor registration, self-registration, dev demo seed) now stamp `createdTime` in Airtable's ISO-8601 format. Previously only Airtable-migrated rows had it.
2. **Drop homework columns** — `homeworkSubmitted` / `homeworkCount` removed from the schema, the insert paths, and the 功課 view (`students:withHomework` + `HomeworkView`) is deleted.
3. **leadingDate/observingDate → leadingSessions/observingSessions** — the legacy scalar dates are merged into the session arrays (dedupe, sorted oldest-first).
4. **Drop source / teachingAssistants** — provenance and legacy Airtable 助教 links removed from schema, inserts, and data.
5. **present = true on every row** — migration sets it; insert paths now default true; the demo reset no longer clears it.
6. **class1-5 backfill** — set to true ONLY when all five marks were blank (attendance never recorded), with the replicated `missed` count recomputed to 0 so the 缺課 column agrees with the all-attended marks.

All data steps run in the idempotent `migrations:cleanupStudentFields` internal mutation, which also backfills `createdTime` from `_creationTime` for app-created rows.

## Deployment state (applied)

- Dev (rugged-oriole-958): migrated + final schema live. Round 1: 91 harmonized, 11 createdTime backfilled. Round 2: 85 class backfills, 176 present fixes, 295 stripped.
- Prod (abundant-dodo-507): migrated + final schema live. Round 1: 91 harmonized, 3 createdTime backfilled. Round 2: 77 class backfills, 168 present fixes, 287 stripped. Re-runs report all zeros (idempotent).
- Note: Convex validates existing documents at schema-push time, so each drop was deployed in two steps — a transitional schema (dropped fields optional) + migration run, then the final schema. Sequence executed on both deployments before merge.

## Coherence updates

- `transform_seed.py`: re-imports emit harmonized session arrays, no homework/助教/source fields; fixes the quarter summary reading the pre-KEY_MAP key.
- README field-name note + roster-views LLD/EARS updated (功課 view removed, Master view no longer claims a source column).