### PR TITLE
chore(roster): drop createdTime — _creationTime is the single, true creation column

### DIFF
--- a/airtable_dump/transform_seed.py
+++ b/airtable_dump/transform_seed.py
@@ -10,13 +10,21 @@
   observingSessions arrays; homework columns are no longer tracked.
 - Replicates the Missed formula (5 - number of checked 課堂) and verifies it
   against Airtable's stored value.
+- Converts Airtable's createdTime into the document's true system
+  `_creationTime` (the single creation-time column in Convex).
 - Writes students_seed.jsonl (one document per line) for `npx convex import`.
 """
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 HERE = Path(__file__).parent  # airtable_dump/ — dumps live here
+
+
+def iso_to_ms(iso: str) -> float:
+    """Parse an ISO-8601 timestamp (Airtable createdTime) to epoch ms."""
+    return datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp() * 1000.0
 
 TBL_STUDENTS = "tblty4DoMC2Pmfrw6"
 LINKS = {
@@ -90,7 +98,9 @@ def main() -> None:
         f = rec["fields"]
         doc = {
             "airtableId": rec["id"],
-            "createdTime": rec["createdTime"],
+            # The system _creationTime is the single creation-time column;
+            # seed imports backfill it with Airtable's true createdTime.
+            "_creationTime": iso_to_ms(rec["createdTime"]),
         }
 
         # Scalar fields, copied as-is.

--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -104,6 +104,15 @@ scalar 带领日期/观察的日期 (harmonized into the
 to true on every row and backfills `class1`-`class5` = true (with
 `missed` = 0) for rows whose five attendance marks were all blank.
 
+There is a single creation-time column: the system `_creationTime`.
+The old `createdTime` string column was dropped by exporting the
+table, rewriting each document's `_creationTime` from its true
+`createdTime` value (Airtable-era rows) and re-importing with
+`npx convex import --table students --replace` (document ids are
+preserved, so session assignments stay wired). `transform_seed.py`
+emits `_creationTime` directly. Audit any deployment with
+`npx convex run migrations:verifyStudents [--prod]`.
+
 ## Local development
 
 ```bash
@@ -158,12 +167,14 @@ One-time-ish scripts for re-dumping and re-importing the Airtable data:
 uv run airtable_dump/dump_airtable.py
 
 # 2. Transform 学员名单 into Convex-ready seed docs (ASCII keys, resolved
-#    links, replicated Missed/count fields + verification report)
+#    links, true _creationTime, replicated Missed field + verification
+#    report)
 uv run airtable_dump/transform_seed.py
 cp airtable_dump/students_seed.jsonl apps/roster/seed/students_seed.jsonl
 
-# 3. Import (add --prod for production)
+# 3. Import (add --prod for production), then run the cleanup migration
 cd apps/roster && npx convex import --table students seed/students_seed.jsonl
+npx convex run migrations:cleanupStudentFields
 ```
 
 ## Known limitations

--- a/apps/roster/convex/auth.ts
+++ b/apps/roster/convex/auth.ts
@@ -179,7 +179,6 @@ export const verifyRegistrationCode = mutation({
         quarter,
         present: true,
         missed: 0,
-        createdTime: new Date().toISOString(),
         photoStorageId: registration.photoStorageId,
       });
     }

--- a/apps/roster/convex/demo.ts
+++ b/apps/roster/convex/demo.ts
@@ -61,7 +61,6 @@ export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
         class4: attended >= 4,
         class5: attended >= 5,
         missed: 5 - attended,
-        createdTime: new Date().toISOString(),
       });
       idByEmail.set(s.email, id);
       studentsAdded++;

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -1,4 +1,4 @@
-import { internalMutation } from "./_generated/server";
+import { internalMutation, internalQuery } from "./_generated/server";
 import type { Doc } from "./_generated/dataModel";
 
 // One-time cleanup (2026-08-31): remove the legacy `clerkId` field from
@@ -39,9 +39,10 @@ export const dropLegacyClerkIds = internalMutation({
 //    mark recorded are left untouched. `missed` (the replicated
 //    unchecked-class count) is recomputed to 0 for those rows so the
 //    缺課 column agrees with the all-attended marks.
-// 5. Backfill createdTime on app-created rows (which never set it) from
-//    the system _creationTime; imported Airtable rows keep their true
-//    value.
+// 5. Strip any leftover `createdTime` field — it was superseded by the
+//    system `_creationTime`, which the export→transform→import
+//    round-trip backfilled with the true creation dates (see README,
+//    "Migration pipeline").
 // Safe to re-run — every pass no-ops when nothing matches. Run via:
 //   npx convex run migrations:cleanupStudentFields [--prod]
 export const cleanupStudentFields = internalMutation({
@@ -51,7 +52,7 @@ export const cleanupStudentFields = internalMutation({
     let stripped = 0;
     let presentSet = 0;
     let classesBackfilled = 0;
-    let createdBackfilled = 0;
+    let createdStripped = 0;
     for (const s of await ctx.db.query("students").collect()) {
       seen++;
       // Cast needed: these fields are deliberately absent from the
@@ -129,11 +130,10 @@ export const cleanupStudentFields = internalMutation({
         classesBackfilled++;
       }
 
-      // App-created rows never set createdTime; backfill it from the
-      // system creation time so every row carries its true date.
-      if (legacy.createdTime === undefined) {
-        patch.createdTime = new Date(s._creationTime).toISOString();
-        createdBackfilled++;
+      // createdTime is superseded by the true system _creationTime.
+      if (legacy.createdTime !== undefined) {
+        patch.createdTime = undefined;
+        createdStripped++;
       }
 
       if (Object.keys(patch).length > 0) {
@@ -150,7 +150,41 @@ export const cleanupStudentFields = internalMutation({
       stripped,
       presentSet,
       classesBackfilled,
-      createdBackfilled,
+      createdStripped,
+    };
+  },
+});
+
+// Data audit (2026-09-05, from the creation-time spike): verifies
+// student/session integrity after the re-imports and that no legacy
+// `createdTime` field remains. Run via:
+//   npx convex run migrations:verifyStudents [--prod]
+export const verifyStudents = internalQuery({
+  handler: async (ctx) => {
+    const students = await ctx.db.query("students").collect();
+    const sessions = await ctx.db.query("sessions").collect();
+    const ids = new Set(students.map((s) => s._id));
+    let danglingSessionRefs = 0;
+    for (const s of sessions) {
+      for (const id of [...s.leaderIds, ...s.observerIds]) {
+        if (!ids.has(id)) danglingSessionRefs++;
+      }
+    }
+    const withLegacyCreatedTime = students.filter(
+      (s) => (s as { createdTime?: string }).createdTime !== undefined,
+    ).length;
+    const times = students.map((s) => s._creationTime);
+    return {
+      count: students.length,
+      sessions: sessions.length,
+      danglingSessionRefs,
+      withLegacyCreatedTime,
+      creationYearRange: students.length
+        ? [
+            new Date(Math.min(...times)).getUTCFullYear(),
+            new Date(Math.max(...times)).getUTCFullYear(),
+          ]
+        : [],
     };
   },
 });

--- a/apps/roster/convex/schema.ts
+++ b/apps/roster/convex/schema.ts
@@ -7,7 +7,6 @@ import { v } from "convex/values";
 export default defineSchema({
   students: defineTable({
     airtableId: v.optional(v.string()),
-    createdTime: v.optional(v.string()),
     name: v.string(),
     fellowship: v.optional(v.string()),
     email: v.optional(v.string()),

--- a/apps/roster/convex/students.ts
+++ b/apps/roster/convex/students.ts
@@ -344,9 +344,6 @@ export const registerStudent = mutation({
       present: true,
       // Attendance starts unrecorded (0 misses recorded), not 5.
       missed: 0,
-      // Airtable-era rows carry createdTime from the dump; new rows
-      // stamp it here (ISO-8601, same format).
-      createdTime: new Date().toISOString(),
       photoStorageId: args.photoStorageId,
     });
     return { status: "created" as const, id };


### PR DESCRIPTION
## Spike answer: YES, they can be harmonized

- `db.insert` **cannot** set `_creationTime` (Convex rejects a mismatch with the system time).
- `npx convex import` **can**: it accepts `_creationTime` and `_id` per document, and `--replace` wipes + re-imports a table with ids preserved — so session `leaderIds`/`observerIds` stay wired.

**End state (this PR):** one creation-time column, `_creationTime`, true on every row — legacy Airtable rows carry their real 2017–2024 signup dates, app-created rows carry their real insert time. The `createdTime` string column is gone from schema, inserts, and data.

## Prototype (dev, verified)

295/295 docs re-imported; sample before/after: 魏庚辰 `_creationTime` 2026-08-31 (import date) → **2023-02-19T19:51:46Z** (true date); `withCreatedTime` 0; `danglingSessionRefs` 0; sessions 52 intact.

## Plan

- Dev: final code pushed, data already harmonized, audit query green.
- Prod: transitional push (new functions + createdTime still optional) → `convex export --prod` backup → transform → `import --replace` → migration (strips stragglers) → audit → merge → Vercel ships final schema + frontend together.