### PR TITLE
chore(roster): drop empty bookOrder column

### DIFF
--- a/airtable_dump/transform_seed.py
+++ b/airtable_dump/transform_seed.py
@@ -54,7 +54,6 @@ KEY_MAP = {
     "Missed": "missed",
     "主领日期": "leadingSessions",
     "观察日期": "observingSessions",
-    "书本订购": "bookOrder",
 }
 
 
@@ -107,7 +106,7 @@ def main() -> None:
         for key in [
             "名字", "團契", "郵箱", "受洗時間", "参与训练的季度", "小组名字",
             "性別", "帶領查經經驗", "出席",
-            *CLASS_CHECKBOXES, "书本订购",
+            *CLASS_CHECKBOXES,
         ]:
             if key in f:
                 doc[key] = f[key]

--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -103,6 +103,8 @@ scalar 带领日期/观察的日期 (harmonized into the
 `migrations:cleanupStudentFields`. The same migration sets `present`
 to true on every row and backfills `class1`-`class5` = true (with
 `missed` = 0) for rows whose five attendance marks were all blank.
+The never-filled `bookOrder` (Airtable 书本订购) was dropped the same
+day.
 
 There is a single creation-time column: the system `_creationTime`.
 The old `createdTime` string column was dropped by exporting the

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -32,7 +32,8 @@ export const dropLegacyClerkIds = internalMutation({
 //    observingSessions arrays.
 // 2. Strip the fields dropped from the schema: the homework columns
 //    (homeworkSubmitted/homeworkCount), the scalar date fields, the
-//    provenance `source`, and the legacy `teachingAssistants` links.
+//    provenance `source`, the legacy `teachingAssistants` links, and
+//    the never-filled `bookOrder`.
 // 3. Set `present` to true on every row.
 // 4. Backfill `class1`-`class5` = true for rows whose five attendance
 //    marks are ALL blank (attendance never recorded); rows with any
@@ -65,6 +66,7 @@ export const cleanupStudentFields = internalMutation({
         homeworkCount?: number;
         source?: string;
         teachingAssistants?: string[];
+        bookOrder?: string;
         createdTime?: string;
       };
       const patch: Record<string, unknown> = {};
@@ -94,7 +96,8 @@ export const cleanupStudentFields = internalMutation({
         legacy.homeworkSubmitted !== undefined ||
         legacy.homeworkCount !== undefined ||
         legacy.source !== undefined ||
-        legacy.teachingAssistants !== undefined
+        legacy.teachingAssistants !== undefined ||
+        legacy.bookOrder !== undefined
       ) {
         patch.leadingDate = undefined;
         patch.observingDate = undefined;
@@ -102,6 +105,7 @@ export const cleanupStudentFields = internalMutation({
         patch.homeworkCount = undefined;
         patch.source = undefined;
         patch.teachingAssistants = undefined;
+        patch.bookOrder = undefined;
         stripped++;
       }
 

--- a/apps/roster/convex/schema.ts
+++ b/apps/roster/convex/schema.ts
@@ -29,7 +29,6 @@ export default defineSchema({
     // now lives on the sessions table.
     leadingSessions: v.optional(v.array(v.string())),
     observingSessions: v.optional(v.array(v.string())),
-    bookOrder: v.optional(v.string()),
     // Optional registration photo (front-camera snap or gallery pick).
     photoStorageId: v.optional(v.id("_storage")),
   })


### PR DESCRIPTION
Fresh exports confirm `bookOrder` (Airtable 书本订购) is completely empty — 0/295 dev docs, 0/287 prod docs carry it. Drops it from the schema and the seed transform; cleanup migration gains a no-op strip for safety. No transitional deploy needed since no documents carry the field (the schema push itself validates that).