### PR TITLE
feat(roster): attendance table + quarter calendars + instructor rule

### DIFF
--- a/airtable_dump/transform_seed.py
+++ b/airtable_dump/transform_seed.py
@@ -8,10 +8,12 @@
   arrays of display values using the other dumps.
 - Generalizes the scalar 带领日期/观察的日期 into the leadingSessions/
   observingSessions arrays; homework columns are no longer tracked.
-- Replicates the Missed formula (5 - number of checked 課堂) and verifies it
   against Airtable's stored value.
 - Converts Airtable's createdTime into the document's true system
   `_creationTime` (the single creation-time column in Convex).
+- Emits present=true and missed=0: attendance lives in the Convex
+  attendance table (one row per student per session date) and is NOT
+  reconstructible from Airtable — preserve it via `convex export`.
 - Writes students_seed.jsonl (one document per line) for `npx convex import`.
 """
 
@@ -32,7 +34,6 @@ LINKS = {
     "观察日期": ("tblQgLBaK0KENUuwT", "观察日期"),
     "功课（提交）": ("tblzkrTts5Fr5kw1l", "功课（提交）"),
 }
-CLASS_CHECKBOXES = ["課堂（一）", "課堂（二）", "課堂（三）", "課堂（四）", "課堂（五）"]
 
 # Convex field names must be non-control ASCII, so documents use English
 # keys (UI labels remain Chinese).
@@ -45,13 +46,6 @@ KEY_MAP = {
     "小组名字": "groupName",
     "性別": "gender",
     "帶領查經經驗": "leadingExperience",
-    "出席": "present",
-    "課堂（一）": "class1",
-    "課堂（二）": "class2",
-    "課堂（三）": "class3",
-    "課堂（四）": "class4",
-    "課堂（五）": "class5",
-    "Missed": "missed",
     "主领日期": "leadingSessions",
     "观察日期": "observingSessions",
 }
@@ -92,7 +86,6 @@ def main() -> None:
     students = json.loads((HERE / f"{TBL_STUDENTS}_table.json").read_text())
 
     docs = []
-    mismatch_missed = 0
     for rec in students:
         f = rec["fields"]
         doc = {
@@ -105,8 +98,7 @@ def main() -> None:
         # Scalar fields, copied as-is.
         for key in [
             "名字", "團契", "郵箱", "受洗時間", "参与训练的季度", "小组名字",
-            "性別", "帶領查經經驗", "出席",
-            *CLASS_CHECKBOXES,
+            "性別", "帶領查經經驗",
         ]:
             if key in f:
                 doc[key] = f[key]
@@ -131,15 +123,11 @@ def main() -> None:
         doc.pop("功课（提交）", None)
         doc.pop("功课提交数目", None)
 
-        # Replicate the Missed formula + verify.
-        computed_missed = sum(1 for c in CLASS_CHECKBOXES if not f.get(c))
-        if "Missed" in f and f["Missed"] != computed_missed:
-            mismatch_missed += 1
-            print(
-                f"  Missed mismatch {rec['id']}: airtable={f['Missed']} "
-                f"computed={computed_missed}"
-            )
-        doc["Missed"] = computed_missed
+        # Attendance lives in the Convex attendance table (one row per
+        # student per session date) and is NOT reconstructible from
+        # Airtable. 出席 is always true; missed starts at 0.
+        doc["present"] = True
+        doc["missed"] = 0
 
         docs.append(doc)
 
@@ -150,7 +138,6 @@ def main() -> None:
             fh.write(json.dumps(ascii_doc, ensure_ascii=False) + "\n")
 
     print(f"wrote {len(docs)} documents -> {out}")
-    print(f"Missed formula mismatches: {mismatch_missed}")
 
     # Quarter distribution (for the 本季度 view sanity check).
     from collections import Counter

--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -88,12 +88,23 @@ is the gate.
 
 Convex requires ASCII field names, so documents use English keys
 (`name`, `fellowship`, `email`, `baptismTime`, `quarter`, `groupName`,
-`gender`, `leadingExperience`, `present`, `class1`-`class5`, `missed`,
+`gender`, `leadingExperience`, `present`, `missed`,
 `leadingSessions`, `observingSessions`, `photoStorageId`); the UI shows
 the original Chinese labels. Linked-record fields were resolved to
-display values at import time (主领日期/观察日期 → 课程日期). The Airtable
-`Missed` formula (unchecked classes, 1-5) is replicated at write time
-and verified to match all 284 migrated records.
+display values at import time (主领日期/观察日期 → 课程日期).
+
+Attendance (出勤) lives in the `attendance` table: one row per
+(student, class date), written through `students:recordAttendance`,
+which validates that the date is an active session date of the
+student's quarter — attendance can never point at a non-class day. A
+quarter's active dates are its rows in the `sessions` table (4-6
+variable weeks, gaps allowed). Quarters whose dates Airtable never
+recorded (2023-2026 spring among others) were synthesized by
+`migrations:backfillAttendance` — first five Sundays of
+April/October — and carry `estimated: true`; correct any wrong date in
+place. `missed` is the replicated absent count, maintained at write
+time. Instructors are never students in the current quarter: enforced
+at both registration paths and by the backfill migration.
 
 Dropped in the 2026-09-05 cleanup: the homework columns
 (功课（提交）→`homeworkSubmitted`, 功课提交数目→`homeworkCount`), the

--- a/apps/roster/convex/auth.ts
+++ b/apps/roster/convex/auth.ts
@@ -142,6 +142,16 @@ export const verifyRegistrationCode = mutation({
     const addr = normalizeEmail(email);
     if (!EMAIL_RE.test(addr)) throw new Error("請填寫有效的電子郵箱");
 
+    // Instructor rule: active instructors are never students in the
+    // current quarter.
+    const instructorRow = await ctx.db
+      .query("instructors")
+      .withIndex("by_email", (q) => q.eq("email", addr))
+      .unique();
+    if (instructorRow?.active === true) {
+      throw new Error("同工不需要報名學員名單");
+    }
+
     const rows = await ctx.db
       .query("authCodes")
       .withIndex("by_email", (q) => q.eq("email", addr))

--- a/apps/roster/convex/demo.ts
+++ b/apps/roster/convex/demo.ts
@@ -1,7 +1,11 @@
 import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
 import type { Id } from "./_generated/dataModel";
-import { CURRENT_QUARTER } from "../src/constants";
+import { upsertAttendance } from "./students";
+import {
+  CURRENT_QUARTER,
+  CURRENT_QUARTER_SESSION_DATES,
+} from "../src/constants";
 
 // Preview/demo seeding: fake students, groups, and a fake 2026秋季 session
 // schedule on the DEV deployment only. Run via
@@ -22,10 +26,11 @@ const FAKE_STUDENTS = [
 // 2026秋季 Sunday schedule. Dates that already exist are patched with the
 // extra assignments rather than duplicated.
 const FAKE_SESSIONS = [
-  { date: "2026-09-13", leaderEmails: ["demo1@demo.sgbs"], observerEmails: ["demo4@demo.sgbs", "demo7@demo.sgbs"] },
-  { date: "2026-09-20", leaderEmails: ["demo5@demo.sgbs", "demo2@demo.sgbs"], observerEmails: ["demo8@demo.sgbs"] },
-  { date: "2026-09-27", leaderEmails: ["demo6@demo.sgbs"], observerEmails: ["demo3@demo.sgbs", "demo5@demo.sgbs"] },
+  { date: "2026-09-20", leaderEmails: ["demo1@demo.sgbs"], observerEmails: ["demo4@demo.sgbs", "demo7@demo.sgbs"] },
+  { date: "2026-09-27", leaderEmails: ["demo5@demo.sgbs", "demo2@demo.sgbs"], observerEmails: ["demo8@demo.sgbs"] },
+  { date: "2026-10-04", leaderEmails: ["demo6@demo.sgbs"], observerEmails: ["demo3@demo.sgbs", "demo5@demo.sgbs"] },
   { date: "2026-10-11", leaderEmails: ["demo4@demo.sgbs", "demo7@demo.sgbs"], observerEmails: ["demo1@demo.sgbs"] },
+  { date: "2026-10-18", leaderEmails: ["demo2@demo.sgbs"], observerEmails: ["demo6@demo.sgbs"] },
 ];
 
 export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
@@ -55,13 +60,13 @@ export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
         groupName: s.groupName,
         quarter: CURRENT_QUARTER,
         present: true,
-        class1: attended >= 1,
-        class2: attended >= 2,
-        class3: attended >= 3,
-        class4: attended >= 4,
-        class5: attended >= 5,
-        missed: 5 - attended,
+        missed: 0,
       });
+      // Attendance: attended the first `attended` sessions, absent for
+      // the rest (upsertAttendance keeps `missed` in sync).
+      for (const [i, date] of CURRENT_QUARTER_SESSION_DATES.entries()) {
+        await upsertAttendance(ctx, id, CURRENT_QUARTER, date, i < attended);
+      }
       idByEmail.set(s.email, id);
       studentsAdded++;
     }
@@ -127,15 +132,14 @@ export const resetQuarterData = internalMutation({
     for (const s of students) {
       if (s.quarter !== CURRENT_QUARTER) continue;
       names.push(s.name);
-      await ctx.db.patch(s._id, {
-        groupName: undefined,
-        missed: 0,
-        class1: undefined,
-        class2: undefined,
-        class3: undefined,
-        class4: undefined,
-        class5: undefined,
-      });
+      const attendanceRows = await ctx.db
+        .query("attendance")
+        .withIndex("by_student", (q) => q.eq("studentId", s._id))
+        .collect();
+      for (const row of attendanceRows) {
+        await ctx.db.delete(row._id);
+      }
+      await ctx.db.patch(s._id, { groupName: undefined, missed: 0 });
       reset++;
     }
     return { reset, names };

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -1,5 +1,10 @@
 import { internalMutation, internalQuery } from "./_generated/server";
-import type { Doc } from "./_generated/dataModel";
+import type { Doc, Id } from "./_generated/dataModel";
+import { upsertAttendance } from "./students";
+import {
+  CURRENT_QUARTER,
+  CURRENT_QUARTER_SESSION_DATES,
+} from "../src/constants";
 
 // One-time cleanup (2026-08-31): remove the legacy `clerkId` field from
 // student rows after dropping the column from the schema. Identity is
@@ -35,15 +40,12 @@ export const dropLegacyClerkIds = internalMutation({
 //    provenance `source`, the legacy `teachingAssistants` links, and
 //    the never-filled `bookOrder`.
 // 3. Set `present` to true on every row.
-// 4. Backfill `class1`-`class5` = true for rows whose five attendance
-//    marks are ALL blank (attendance never recorded); rows with any
-//    mark recorded are left untouched. `missed` (the replicated
-//    unchecked-class count) is recomputed to 0 for those rows so the
-//    缺課 column agrees with the all-attended marks.
-// 5. Strip any leftover `createdTime` field — it was superseded by the
+// 4. Strip any leftover `createdTime` field — it was superseded by the
 //    system `_creationTime`, which the export→transform→import
 //    round-trip backfilled with the true creation dates (see README,
 //    "Migration pipeline").
+// (The legacy class1-5 marks moved to the attendance table — see
+// migrations:backfillAttendance.)
 // Safe to re-run — every pass no-ops when nothing matches. Run via:
 //   npx convex run migrations:cleanupStudentFields [--prod]
 export const cleanupStudentFields = internalMutation({
@@ -52,7 +54,6 @@ export const cleanupStudentFields = internalMutation({
     let harmonized = 0;
     let stripped = 0;
     let presentSet = 0;
-    let classesBackfilled = 0;
     let createdStripped = 0;
     for (const s of await ctx.db.query("students").collect()) {
       seen++;
@@ -115,25 +116,6 @@ export const cleanupStudentFields = internalMutation({
         presentSet++;
       }
 
-      // class1-5: backfill true only when ALL five marks are blank
-      // (attendance never recorded); recompute the replicated missed
-      // count so it agrees with the marks.
-      if (
-        s.class1 === undefined &&
-        s.class2 === undefined &&
-        s.class3 === undefined &&
-        s.class4 === undefined &&
-        s.class5 === undefined
-      ) {
-        patch.class1 = true;
-        patch.class2 = true;
-        patch.class3 = true;
-        patch.class4 = true;
-        patch.class5 = true;
-        patch.missed = 0;
-        classesBackfilled++;
-      }
-
       // createdTime is superseded by the true system _creationTime.
       if (legacy.createdTime !== undefined) {
         patch.createdTime = undefined;
@@ -153,7 +135,6 @@ export const cleanupStudentFields = internalMutation({
       harmonized,
       stripped,
       presentSet,
-      classesBackfilled,
       createdStripped,
     };
   },
@@ -177,12 +158,28 @@ export const verifyStudents = internalQuery({
     const withLegacyCreatedTime = students.filter(
       (s) => (s as { createdTime?: string }).createdTime !== undefined,
     ).length;
+    const withLegacyClassMarks = students.filter(
+      (s) => (s as { class1?: boolean }).class1 !== undefined,
+    ).length;
+    const attendance = await ctx.db.query("attendance").collect();
+    const seenDates = new Set<string>();
+    let duplicateSessionDates = 0;
+    for (const sess of sessions) {
+      const key = `${sess.quarter}:${sess.date}`;
+      if (seenDates.has(key)) duplicateSessionDates++;
+      seenDates.add(key);
+    }
     const times = students.map((s) => s._creationTime);
     return {
       count: students.length,
       sessions: sessions.length,
       danglingSessionRefs,
       withLegacyCreatedTime,
+      withLegacyClassMarks,
+      attendanceRows: attendance.length,
+      attendanceAbsent: attendance.filter((a) => !a.attended).length,
+      estimatedSessions: sessions.filter((s) => s.estimated === true).length,
+      duplicateSessionDates,
       creationYearRange: students.length
         ? [
             new Date(Math.min(...times)).getUTCFullYear(),
@@ -190,5 +187,194 @@ export const verifyStudents = internalQuery({
           ]
         : [],
     };
+  },
+});
+
+// First Sunday of a month (UTC), then the following four Sundays.
+function sundaysOf(quarter: string): string[] {
+  const m = /^(20\d{2})\s*(春季|秋季)$/.exec(quarter);
+  if (!m) return [];
+  const year = Number(m[1]);
+  const month = m[2] === "春季" ? 4 : 10;
+  const first = new Date(Date.UTC(year, month - 1, 1));
+  first.setUTCDate(first.getUTCDate() + ((7 - first.getUTCDay()) % 7));
+  const out: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    out.push(first.toISOString().slice(0, 10));
+    first.setUTCDate(first.getUTCDate() + 7);
+  }
+  return out;
+}
+
+// One-time attendance backfill (2026-09-05) introducing the attendance
+// table:
+// 1. Enforce the instructor rule: active instructors are never students
+//    in the current quarter — their current-quarter rows are deleted.
+// 2. Normalize session quarter "2020春季" to the canonical "2020 春季".
+// 3. Dedupe session rows sharing (quarter, date), merging assignments
+//    into the oldest row (2019春季 had duplicates).
+// 4. Ensure the current quarter's five class dates exist.
+// 5. Synthesize calendars for quarters that have students but no
+//    session rows — Airtable's 课程日期 never recorded them. Dates are
+//    the first five Sundays of April/October, flagged estimated: true;
+//    correct any wrong date in place.
+// 6. Backfill attendance from the legacy positional class1-5 marks
+//    (Nth mark → Nth session date of the quarter), then strip the
+//    legacy fields.
+// Idempotent — every step no-ops once applied. Run via:
+//   npx convex run migrations:backfillAttendance [--prod]
+export const backfillAttendance = internalMutation({
+  handler: async (ctx) => {
+    const report = {
+      instructorRowsDeleted: [] as string[],
+      quartersNormalized: 0,
+      sessionsDeduped: 0,
+      sessionsEnsured: 0,
+      quartersSynthesized: [] as string[],
+      studentsSeen: 0,
+      studentsStripped: 0,
+      attendanceCreated: 0,
+    };
+
+    // 1. Instructors are never students in the current quarter.
+    const instructors = await ctx.db.query("instructors").collect();
+    const activeEmails = new Set(
+      instructors.filter((i) => i.active === true).map((i) => i.email),
+    );
+    for (const s of await ctx.db.query("students").collect()) {
+      if (
+        s.quarter === CURRENT_QUARTER &&
+        s.email &&
+        activeEmails.has(s.email)
+      ) {
+        if (s.photoStorageId) await ctx.storage.delete(s.photoStorageId);
+        await ctx.db.delete(s._id);
+        report.instructorRowsDeleted.push(s.name);
+      }
+    }
+
+    // 2. Canonical quarter name for sessions (QUARTERS has the space).
+    for (const sess of await ctx.db.query("sessions").collect()) {
+      if (sess.quarter === "2020春季") {
+        await ctx.db.patch(sess._id, { quarter: "2020 春季" });
+        report.quartersNormalized++;
+      }
+    }
+
+    // 3. Dedupe (quarter, date) sessions, merging assignments.
+    const seen = new Map<string, Id<"sessions">>();
+    const allSessions = (await ctx.db.query("sessions").collect()).sort(
+      (a, b) => a._creationTime - b._creationTime,
+    );
+    for (const sess of allSessions) {
+      const key = `${sess.quarter}:${sess.date}`;
+      const keeperId = seen.get(key);
+      if (keeperId === undefined) {
+        seen.set(key, sess._id);
+        continue;
+      }
+      const keeper = await ctx.db.get(keeperId);
+      if (keeper) {
+        await ctx.db.patch(keeper._id, {
+          leaderIds: [...new Set([...keeper.leaderIds, ...sess.leaderIds])],
+          observerIds: [
+            ...new Set([...keeper.observerIds, ...sess.observerIds]),
+          ],
+        });
+      }
+      await ctx.db.delete(sess._id);
+      report.sessionsDeduped++;
+    }
+
+    // 4. Ensure the current quarter's five class dates.
+    const currentDateSet = new Set(
+      (await ctx.db.query("sessions").collect())
+        .filter((s) => s.quarter === CURRENT_QUARTER)
+        .map((s) => s.date),
+    );
+    for (const date of CURRENT_QUARTER_SESSION_DATES) {
+      if (!currentDateSet.has(date)) {
+        await ctx.db.insert("sessions", {
+          date,
+          quarter: CURRENT_QUARTER,
+          leaderIds: [],
+          observerIds: [],
+        });
+        report.sessionsEnsured++;
+      }
+    }
+
+    // 5. Synthesize calendars for student-bearing quarters without one.
+    const students = await ctx.db.query("students").collect();
+    const quartersWithSessions = new Set(
+      (await ctx.db.query("sessions").collect()).map((s) => s.quarter),
+    );
+    const quartersWithStudents = new Set(
+      students
+        .map((s) => s.quarter)
+        .filter((q): q is string => q !== undefined),
+    );
+    for (const q of quartersWithStudents) {
+      if (quartersWithSessions.has(q)) continue;
+      for (const date of sundaysOf(q)) {
+        await ctx.db.insert("sessions", {
+          date,
+          quarter: q,
+          leaderIds: [],
+          observerIds: [],
+          estimated: true,
+        });
+      }
+      report.quartersSynthesized.push(q);
+    }
+
+    // 6. Legacy positional marks → attendance rows.
+    for (const s of students) {
+      report.studentsSeen++;
+      if (!s.quarter) continue;
+      const legacy = s as {
+        class1?: boolean;
+        class2?: boolean;
+        class3?: boolean;
+        class4?: boolean;
+        class5?: boolean;
+      };
+      const marks = [
+        legacy.class1,
+        legacy.class2,
+        legacy.class3,
+        legacy.class4,
+        legacy.class5,
+      ];
+      if (marks.every((m) => m === undefined)) continue;
+      const quarterSessions = (
+        await ctx.db
+          .query("sessions")
+          .withIndex("by_quarter", (q) => q.eq("quarter", s.quarter))
+          .collect()
+      ).sort((a, b) => a.date.localeCompare(b.date));
+      for (let i = 0; i < marks.length; i++) {
+        const mark = marks[i];
+        const sess = quarterSessions[i];
+        if (mark === undefined || sess === undefined) continue;
+        const result = await upsertAttendance(
+          ctx,
+          s._id,
+          s.quarter,
+          sess.date,
+          mark,
+        );
+        if (result === "created") report.attendanceCreated++;
+      }
+      await ctx.db.patch(s._id, {
+        class1: undefined,
+        class2: undefined,
+        class3: undefined,
+        class4: undefined,
+        class5: undefined,
+      } as unknown as Partial<Doc<"students">>);
+      report.studentsStripped++;
+    }
+    return report;
   },
 });

--- a/apps/roster/convex/schema.ts
+++ b/apps/roster/convex/schema.ts
@@ -15,13 +15,11 @@ export default defineSchema({
     groupName: v.optional(v.string()),
     gender: v.optional(v.string()),
     leadingExperience: v.optional(v.string()),
+    // 出席 is true on every row (2026-09-05 cleanup).
     present: v.optional(v.boolean()),
-    class1: v.optional(v.boolean()),
-    class2: v.optional(v.boolean()),
-    class3: v.optional(v.boolean()),
-    class4: v.optional(v.boolean()),
-    class5: v.optional(v.boolean()),
-    // Replicated Airtable formula: number of unchecked classes (1-5).
+    // Replicated count: this row's attendance rows marked absent —
+    // maintained at write time by recordAttendance / the backfill
+    // migration (successor of the Airtable Missed formula).
     missed: v.number(),
     // Legacy per-student assignment history (Airtable 主领日期/观察日期
     // links plus the older scalar 带领日期/观察的日期, harmonized into
@@ -38,7 +36,12 @@ export default defineSchema({
 
   // 课程日期 (tblQgLBaK0KENUuwT): one class session with its leading and
   // observing assignments. The session row is the source of truth; the
-  // per-student views derive from these arrays.
+  // per-student views derive from these arrays. A quarter is "active"
+  // on exactly the dates listed here — 4-6 variable weeks, gaps allowed.
+  // Quarters whose dates Airtable never recorded were synthesized by
+  // migrations:backfillAttendance and carry estimated: true (first five
+  // Sundays of April/October). Correct any wrong date in place; the
+  // attendance rows follow the (quarter, date) pair, not the estimate.
   sessions: defineTable({
     date: v.string(),
     quarter: v.optional(v.string()),
@@ -52,10 +55,29 @@ export default defineSchema({
     // removed by the migrations:wireSessionAssignments migration.
     leaderAirtableIds: v.optional(v.array(v.string())),
     observerAirtableIds: v.optional(v.array(v.string())),
+    // True for synthesized calendar rows (Airtable lacked the dates).
+    estimated: v.optional(v.boolean()),
   }).index("by_quarter", ["quarter"]),
+
+  // 出勤記錄: one row per (student, class date) — a student's attendance
+  // for a specific session of their quarter. Writes go through
+  // recordAttendance, which validates that `date` is an active session
+  // date of the student's quarter. A missing row means "not recorded";
+  // attended=false means the student was absent.
+  attendance: defineTable({
+    studentId: v.id("students"),
+    quarter: v.string(),
+    date: v.string(),
+    attended: v.boolean(),
+  })
+    .index("by_student", ["studentId"])
+    .index("by_quarter_date", ["quarter", "date"]),
 
   // 同工 / instructors: emails allowed to see and edit everything.
   // active=false rows are kept for history but have no access.
+  // The instructor rule: active instructors are never students in the
+  // current quarter (enforced at registration and by the backfill
+  // migration).
   instructors: defineTable({
     email: v.string(),
     name: v.optional(v.string()),

--- a/apps/roster/convex/students.ts
+++ b/apps/roster/convex/students.ts
@@ -83,13 +83,119 @@ export const observers = query({
   },
 });
 
-// Missed: students who missed at least one class.
-export const withMissed = query({
-  handler: async (ctx) => {
+// 出勤: per-student attendance marks over a quarter's session dates.
+// `marks` align with `dates` (same order); each is yes/no, or none when
+// attendance was never recorded for that date.
+export const quarterAttendance = query({
+  args: { quarter: v.optional(v.string()) },
+  handler: async (ctx, { quarter }) => {
     await requireInstructor(ctx);
-    return (await ctx.db.query("students").collect()).filter(
-      (s) => s.missed > 0,
+    const q = quarter ?? CURRENT_QUARTER;
+    const sessions = (
+      await ctx.db
+        .query("sessions")
+        .withIndex("by_quarter", (x) => x.eq("quarter", q))
+        .collect()
+    ).sort((a, b) => a.date.localeCompare(b.date));
+    const students = await ctx.db
+      .query("students")
+      .withIndex("by_quarter", (x) => x.eq("quarter", q))
+      .collect();
+    const rows = await ctx.db
+      .query("attendance")
+      .withIndex("by_quarter_date", (x) => x.eq("quarter", q))
+      .collect();
+    const attendedAt = new Map(
+      rows.map((r) => [`${r.studentId}:${r.date}`, r.attended]),
     );
+    type Mark = "yes" | "no" | "none";
+    return {
+      quarter: q,
+      dates: sessions.map((s) => s.date),
+      students: students.map((s) => ({
+        _id: s._id,
+        name: s.name,
+        fellowship: s.fellowship ?? "",
+        missed: s.missed,
+        marks: sessions.map((sess): Mark => {
+          const a = attendedAt.get(`${s._id}:${sess.date}`);
+          return a === undefined ? "none" : a ? "yes" : "no";
+        }),
+      })),
+    };
+  },
+});
+
+// ---- Attendance writes (出勤) ----
+
+// Upsert one (student, date) attendance row and keep the replicated
+// `missed` count in sync. Callers must validate that `date` is an
+// active session date of `quarter` — recordAttendance does; the
+// backfill migration maps positional marks against the quarter's
+// calendar instead.
+export async function upsertAttendance(
+  ctx: MutationCtx,
+  studentId: Id<"students">,
+  quarter: string,
+  date: string,
+  attended: boolean,
+): Promise<"created" | "updated" | "unchanged"> {
+  const existingRows = await ctx.db
+    .query("attendance")
+    .withIndex("by_student", (q) => q.eq("studentId", studentId))
+    .collect();
+  const existing = existingRows.find((a) => a.date === date);
+  let result: "created" | "updated" | "unchanged" = "unchanged";
+  if (existing) {
+    if (existing.attended !== attended) {
+      await ctx.db.patch(existing._id, { attended });
+      result = "updated";
+    }
+  } else {
+    await ctx.db.insert("attendance", {
+      studentId,
+      quarter,
+      date,
+      attended,
+    });
+    result = "created";
+  }
+  const missed = (
+    await ctx.db
+      .query("attendance")
+      .withIndex("by_student", (q) => q.eq("studentId", studentId))
+      .collect()
+  ).filter((a) => !a.attended).length;
+  const student = await ctx.db.get(studentId);
+  if (student && student.missed !== missed) {
+    await ctx.db.patch(studentId, { missed });
+  }
+  return result;
+}
+
+// Record one attendance mark (instructors only). The class date must be
+// an active session date of the student's quarter — the write is
+// rejected otherwise, so attendance can never point at a non-class day.
+export const recordAttendance = mutation({
+  args: {
+    studentId: v.id("students"),
+    date: v.string(),
+    attended: v.boolean(),
+  },
+  handler: async (ctx, { studentId, date, attended }) => {
+    await requireInstructor(ctx);
+    const student = await ctx.db.get(studentId);
+    if (!student) throw new Error("找不到此學員");
+    const quarter = student.quarter;
+    if (!quarter) throw new Error("學員沒有所屬季度");
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_quarter", (q) => q.eq("quarter", quarter))
+      .collect();
+    if (!sessions.some((s) => s.date === date)) {
+      throw new Error("此日期不是該季的上課日期");
+    }
+    await upsertAttendance(ctx, studentId, quarter, date, attended);
   },
 });
 
@@ -305,6 +411,11 @@ export const registerStudent = mutation({
     const targetEmail = args.email.trim().toLowerCase();
     if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(targetEmail)) {
       throw new Error("請填寫有效的電子郵箱");
+    }
+    // Instructor rule: active instructors are never students in the
+    // current quarter.
+    if (await isInstructor(ctx, targetEmail)) {
+      throw new Error("同工不需要報名學員名單");
     }
     const targetName = args.name.trim();
 

--- a/apps/roster/src/Roster.tsx
+++ b/apps/roster/src/Roster.tsx
@@ -213,19 +213,27 @@ function ObserversView() {
   );
 }
 
+type Mark = "yes" | "no" | "none";
+
 function MissedView() {
-  const students = useQuery(api.students.withMissed);
-  const photos = useQuery(api.students.photoUrls);
+  const data = useQuery(api.students.quarterAttendance, {});
+  if (!data) return <Loading />;
+  const rows = data.students
+    .filter((s) => s.marks.includes("no"))
+    .sort((a, b) => a.name.localeCompare(b.name, "zh-Hant"));
   return (
     <div>
       <StudentTable
-        students={students}
-        photos={photos}
+        students={rows}
         markColumns
         columns={[
           ["名字", (s) => s.name, "serif"],
-          ["團契", (s) => s.fellowship ?? ""],
-          ["缺課", (s) => String(s.missed), "margin"],
+          ["團契", (s) => s.fellowship],
+          [
+            "缺課",
+            (s) => String(s.marks.filter((m) => m === "no").length),
+            "margin",
+          ],
         ]}
       />
       <BeatLegend />
@@ -235,22 +243,17 @@ function MissedView() {
 
 // ---- Attendance beat line (the Missed view's marks) ----
 
-function BeatMarks({
-  s,
-}: {
-  s: Pick<Student, "class1" | "class2" | "class3" | "class4" | "class5">;
-}) {
-  const marks = [s.class1, s.class2, s.class3, s.class4, s.class5];
-  const yes = marks.filter((m) => m === true).length;
-  const no = marks.filter((m) => m === false).length;
+function DateMarks({ marks }: { marks: Mark[] }) {
+  const yes = marks.filter((m) => m === "yes").length;
+  const no = marks.filter((m) => m === "no").length;
   return (
     <span
       className="inline-flex items-center gap-1.5"
       role="img"
       aria-label={`課堂出席：${yes} 堂出席、${no} 堂缺席`}
     >
-      {marks.map((attended, i) => (
-        <Mark key={i} state={attended === undefined ? "none" : attended ? "yes" : "no"} />
+      {marks.map((state, i) => (
+        <Mark key={i} state={state} />
       ))}
     </span>
   );
@@ -377,11 +380,7 @@ function StudentTable<
     _id: Id<"students">;
     name: string;
     photoStorageId?: Id<"_storage">;
-    class1?: boolean;
-    class2?: boolean;
-    class3?: boolean;
-    class4?: boolean;
-    class5?: boolean;
+    marks?: Mark[];
   },
 >({
   students,
@@ -427,7 +426,7 @@ function StudentTable<
                 scope="col"
                 className="th-double px-3 py-2.5 text-[13px] font-bold tracking-[0.2em] text-ink-soft"
               >
-                課堂（一至五）
+                課堂日期
               </th>
             )}
           </tr>
@@ -472,7 +471,7 @@ function StudentTable<
               ))}
               {markColumns && (
                 <td className="px-3 py-2.5">
-                  <BeatMarks s={s} />
+                  <DateMarks marks={s.marks ?? []} />
                 </td>
               )}
             </tr>

--- a/apps/roster/src/constants.ts
+++ b/apps/roster/src/constants.ts
@@ -12,6 +12,17 @@ export const QUARTERS = [
 // The newest quarter — what the 本季度 view and new registrations use.
 export const CURRENT_QUARTER = "2026秋季";
 
+// The five class dates of the current season (Sundays, 2026-09-20
+// onward). The sessions table is the runtime source of truth; this
+// list seeds it and anchors the demo data.
+export const CURRENT_QUARTER_SESSION_DATES = [
+  "2026-09-20",
+  "2026-09-27",
+  "2026-10-04",
+  "2026-10-11",
+  "2026-10-18",
+] as const;
+
 export const FELLOWSHIPS = [
   "樂河團契",
   "學生團契（研究生）",


### PR DESCRIPTION
## Schema

- **`attendance` table**: one row per (student, class date), `attended` boolean. Writes go through `students:recordAttendance` (instructor-only), which **validates the date is an active session date of the student's quarter** — attendance can never point at a non-class day. Missing row = not recorded.
- **Quarter calendars**: a quarter is active on exactly the dates of its `sessions` rows (4-6 weeks, gaps allowed). Airtable's 课程日期 never recorded 11 quarters that have students (2023-2026 spring among others, plus 2015/2016 fall, 2020 fall, 2021 spring) — `migrations:backfillAttendance` synthesizes them (first five Sundays of April/October) flagged `estimated: true`; correct any wrong date in place.
- **Instructor rule**: active instructors are never students in the current quarter — enforced at both registration paths; the backfill deletes the two violating prod rows (Eric Ma, 林意).
- Legacy positional `class1`-`class5` dropped; `missed` is maintained at write time from attendance.

## Also

- 缺課 view renders per-date marks from `students:quarterAttendance` (works with variable-length quarters).
- Session data hygiene: 2019春季 duplicates deduped (assignments merged), `2020春季` → `2020 春季` normalized, 2026秋季 dates ensured (2026-09-20..10-18).
- `transform_seed.py`: attendance fields no longer emitted (not reconstructible from Airtable); fixes the 书本订购 copy-list remnant left by #130.
- `verifyStudents` audit now reports attendance rows, absent count, estimated sessions, duplicate dates.