### PR TITLE
feat(roster): backfill legacy attendance gaps as explicit absences

### DIFF
--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -106,6 +106,11 @@ place. `missed` is the replicated absent count, maintained at write
 time. Instructors are never students in the current quarter: enforced
 at both registration paths and by the backfill migration.
 
+For legacy seasons, unrecorded classes were backfilled as explicit
+absences (`migrations:backfillLegacyAbsences`) — Airtable's unchecked
+課堂 box meant absent, and the Missed formula counted it. In the
+current quarter, classes that haven't been marked stay unrecorded.
+
 Dropped in the 2026-09-05 cleanup: the homework columns
 (功课（提交）→`homeworkSubmitted`, 功课提交数目→`homeworkCount`), the
 scalar 带领日期/观察的日期 (harmonized into the

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -378,3 +378,52 @@ export const backfillAttendance = internalMutation({
     return report;
   },
 });
+
+// One-time legacy-absence backfill (2026-09-05): Airtable stored
+// unchecked 課堂 boxes by omission, and the first attendance backfill
+// only recorded the checked (attended) classes — so past-season gaps
+// stayed "unrecorded". In Airtable's own semantics (the Missed
+// formula counted unchecked as missed) those gaps meant absent, so
+// this pass records every remaining (student, session date) pair of a
+// PAST quarter as an explicit absence. The current quarter is
+// untouched: its classes haven't happened, so unrecorded stays
+// unrecorded there until marked.
+// Idempotent — every gap already recorded no-ops. Run via:
+//   npx convex run migrations:backfillLegacyAbsences [--prod]
+export const backfillLegacyAbsences = internalMutation({
+  handler: async (ctx) => {
+    let students = 0;
+    let absencesCreated = 0;
+    for (const s of await ctx.db.query("students").collect()) {
+      if (!s.quarter || s.quarter === CURRENT_QUARTER) continue;
+      const sessions = (
+        await ctx.db
+          .query("sessions")
+          .withIndex("by_quarter", (q) => q.eq("quarter", s.quarter))
+          .collect()
+      ).sort((a, b) => a.date.localeCompare(b.date));
+      if (sessions.length === 0) continue;
+      students++;
+      const recorded = new Set(
+        (
+          await ctx.db
+            .query("attendance")
+            .withIndex("by_student", (q) => q.eq("studentId", s._id))
+            .collect()
+        ).map((r) => r.date),
+      );
+      for (const sess of sessions) {
+        if (recorded.has(sess.date)) continue;
+        const result = await upsertAttendance(
+          ctx,
+          s._id,
+          s.quarter,
+          sess.date,
+          false,
+        );
+        if (result === "created") absencesCreated++;
+      }
+    }
+    return { students, absencesCreated };
+  },
+});


### PR DESCRIPTION
Airtable's unchecked 課堂 box meant **absent** (the Missed formula counted it), but it was stored by omission — so the first attendance backfill recorded only attended classes and left past-season gaps as 'unrecorded'. `migrations:backfillLegacyAbsences` records every remaining (student, session date) pair of a **past** quarter as `attended: false`, restoring the original missed counts as real rows. The current quarter (2026秋季, classes start 09-20) is untouched: unrecorded stays unrecorded until instructors mark it. Idempotent.