### PR TITLE
feat(roster): single source of truth for assignments — reconcile legacy arrays into sessions

### DIFF
--- a/airtable_dump/transform_seed.py
+++ b/airtable_dump/transform_seed.py
@@ -4,10 +4,9 @@
 """Transform the Airtable 学员名单 dump into Convex-ready seed documents.
 
 - Flattens record.fields into top-level keys (Chinese field names preserved).
-- Resolves multipleRecordLinks (主领日期/观察日期 -> 课程日期) into
-  arrays of display values using the other dumps.
-- Generalizes the scalar 带领日期/观察的日期 into the leadingSessions/
-  observingSessions arrays; homework columns are no longer tracked.
+- Assignments (主领日期/观察日期) are NOT imported: they live in the
+  sessions table (leaderIds/observerIds), already reconciled from the
+  legacy per-student arrays.
   against Airtable's stored value.
 - Converts Airtable's createdTime into the document's true system
   `_creationTime` (the single creation-time column in Convex).
@@ -30,8 +29,6 @@ def iso_to_ms(iso: str) -> float:
 
 TBL_STUDENTS = "tblty4DoMC2Pmfrw6"
 LINKS = {
-    "主领日期": ("tblQgLBaK0KENUuwT", "主领日期"),
-    "观察日期": ("tblQgLBaK0KENUuwT", "观察日期"),
     "功课（提交）": ("tblzkrTts5Fr5kw1l", "功课（提交）"),
 }
 
@@ -46,8 +43,6 @@ KEY_MAP = {
     "小组名字": "groupName",
     "性別": "gender",
     "帶領查經經驗": "leadingExperience",
-    "主领日期": "leadingSessions",
-    "观察日期": "observingSessions",
 }
 
 
@@ -111,15 +106,9 @@ def main() -> None:
                 for rid in ids if rid in lookup[ref_table]
             ]
 
-        # Generalize the scalar 带领日期/观察的日期 into the session
-        # arrays; homework columns are no longer tracked in Convex.
-        for sessions_key, scalar_key in (
-            ("主领日期", "带领日期"),
-            ("观察日期", "观察的日期"),
-        ):
-            scalar = doc.pop(scalar_key, None)
-            if scalar and scalar not in doc[sessions_key]:
-                doc[sessions_key] = [*doc[sessions_key], scalar]
+        # Assignments live in the sessions table (leaderIds/observerIds),
+        # already reconciled from the legacy per-student arrays; they are
+        # not imported from Airtable.
         doc.pop("功课（提交）", None)
         doc.pop("功课提交数目", None)
 

--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -89,9 +89,14 @@ is the gate.
 Convex requires ASCII field names, so documents use English keys
 (`name`, `fellowship`, `email`, `baptismTime`, `quarter`, `groupName`,
 `gender`, `leadingExperience`, `present`, `missed`,
-`leadingSessions`, `observingSessions`, `photoStorageId`); the UI shows
-the original Chinese labels. Linked-record fields were resolved to
-display values at import time (主领日期/观察日期 → 课程日期).
+`photoStorageId`); the UI shows the original Chinese labels.
+
+Leading/observing assignments live only in the `sessions` table
+(`leaderIds`/`observerIds`); the per-student views derive them at
+query time, so there is no second copy to drift. The legacy
+per-student assignment arrays were reconciled into sessions and
+dropped (`migrations:reconcileAssignments`), surfacing real class
+dates the calendar had lacked (e.g. 2023春季 ran Feb-Mar).
 
 Attendance (出勤) lives in the `attendance` table: one row per
 (student, class date), written through `students:recordAttendance`,
@@ -113,8 +118,7 @@ current quarter, classes that haven't been marked stay unrecorded.
 
 Dropped in the 2026-09-05 cleanup: the homework columns
 (功课（提交）→`homeworkSubmitted`, 功课提交数目→`homeworkCount`), the
-scalar 带领日期/观察的日期 (harmonized into the
-`leadingSessions`/`observingSessions` arrays), `source`, and
+scalar 带领日期/观察的日期, `source`, and
 `teachingAssistants` — all stripped from existing rows by
 `migrations:cleanupStudentFields`. The same migration sets `present`
 to true on every row and backfills `class1`-`class5` = true (with

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -32,15 +32,12 @@ export const dropLegacyClerkIds = internalMutation({
 });
 
 // One-time cleanup (2026-09-05) accompanying the schema slim-down:
-// 1. Harmonize the legacy scalar dates (leadingDate/observingDate, from
-//    Airtable 带领日期/观察的日期) into the leadingSessions/
-//    observingSessions arrays.
-// 2. Strip the fields dropped from the schema: the homework columns
+// 1. Strip the fields dropped from the schema: the homework columns
 //    (homeworkSubmitted/homeworkCount), the scalar date fields, the
 //    provenance `source`, the legacy `teachingAssistants` links, and
 //    the never-filled `bookOrder`.
-// 3. Set `present` to true on every row.
-// 4. Strip any leftover `createdTime` field — it was superseded by the
+// 2. Set `present` to true on every row.
+// 3. Strip any leftover `createdTime` field — it was superseded by the
 //    system `_creationTime`, which the export→transform→import
 //    round-trip backfilled with the true creation dates (see README,
 //    "Migration pipeline").
@@ -51,7 +48,6 @@ export const dropLegacyClerkIds = internalMutation({
 export const cleanupStudentFields = internalMutation({
   handler: async (ctx) => {
     let seen = 0;
-    let harmonized = 0;
     let stripped = 0;
     let presentSet = 0;
     let createdStripped = 0;
@@ -71,24 +67,6 @@ export const cleanupStudentFields = internalMutation({
         createdTime?: string;
       };
       const patch: Record<string, unknown> = {};
-
-      // Merge the scalar date into the session array (dedupe; sorted
-      // oldest-first when every entry is an ISO date).
-      const merge = (
-        scalar: string | undefined,
-        sessions: string[] | undefined,
-      ): string[] | undefined => {
-        if (!scalar) return undefined;
-        const merged = [...new Set([...(sessions ?? []), scalar])];
-        if (merged.every((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))) {
-          merged.sort();
-        }
-        return merged;
-      };
-      const leading = merge(legacy.leadingDate, s.leadingSessions);
-      if (leading) patch.leadingSessions = leading;
-      const observing = merge(legacy.observingDate, s.observingSessions);
-      if (observing) patch.observingSessions = observing;
 
       // Unset the fields removed from the schema.
       if (
@@ -127,12 +105,10 @@ export const cleanupStudentFields = internalMutation({
           s._id,
           patch as unknown as Partial<Doc<"students">>,
         );
-        if (leading || observing) harmonized++;
       }
     }
     return {
       seen,
-      harmonized,
       stripped,
       presentSet,
       createdStripped,
@@ -180,6 +156,10 @@ export const verifyStudents = internalQuery({
       attendanceAbsent: attendance.filter((a) => !a.attended).length,
       estimatedSessions: sessions.filter((s) => s.estimated === true).length,
       duplicateSessionDates,
+      assignmentWires: sessions.reduce(
+        (n, s) => n + s.leaderIds.length + s.observerIds.length,
+        0,
+      ),
       creationYearRange: students.length
         ? [
             new Date(Math.min(...times)).getUTCFullYear(),
@@ -425,5 +405,93 @@ export const backfillLegacyAbsences = internalMutation({
       }
     }
     return { students, absencesCreated };
+  },
+});
+
+// One-time assignment reconciliation (2026-09-05): the legacy
+// per-student leadingSessions/observingSessions arrays held assignment
+// history the sessions table lacked — students wired in the arrays but
+// not in leaderIds/observerIds, and real class dates never recorded in
+// the 课程日期 calendar (e.g. 2023春季 ran Feb-Mar, not the synthesized
+// April Sundays). This pass creates the missing session rows
+// (estimated: true), wires every stored date into the sessions table,
+// then strips the arrays — leaving sessions.leaderIds/observerIds the
+// single source of assignment truth, with the per-student views
+// deriving from it. Idempotent: wiring dedupes; the strip no-ops once
+// applied. Run via: npx convex run migrations:reconcileAssignments [--prod]
+export const reconcileAssignments = internalMutation({
+  handler: async (ctx) => {
+    const report = {
+      sessionsCreated: 0,
+      wiresAdded: 0,
+      studentsStripped: 0,
+    };
+    const sessionsByKey = new Map(
+      (await ctx.db.query("sessions").collect()).map((s) => [
+        `${s.quarter}:${s.date}`,
+        s,
+      ]),
+    );
+    const pending = new Map<
+      Id<"sessions">,
+      { leaderIds: Id<"students">[]; observerIds: Id<"students">[] }
+    >();
+    for (const s of await ctx.db.query("students").collect()) {
+      const arrays = s as {
+        leadingSessions?: string[];
+        observingSessions?: string[];
+      };
+      const roles = [
+        { dates: arrays.leadingSessions, field: "leaderIds" },
+        { dates: arrays.observingSessions, field: "observerIds" },
+      ] as const;
+      let touched = false;
+      for (const { dates, field } of roles) {
+        for (const date of dates ?? []) {
+          if (!s.quarter) continue;
+          const key = `${s.quarter}:${date}`;
+          let sess = sessionsByKey.get(key);
+          if (!sess) {
+            const id = await ctx.db.insert("sessions", {
+              date,
+              quarter: s.quarter,
+              leaderIds: [],
+              observerIds: [],
+              estimated: true,
+            });
+            sess = (await ctx.db.get(id))!;
+            sessionsByKey.set(key, sess);
+            report.sessionsCreated++;
+          }
+          if (sess[field].includes(s._id)) continue;
+          const slot = pending.get(sess._id) ?? {
+            leaderIds: [],
+            observerIds: [],
+          };
+          slot[field].push(s._id);
+          pending.set(sess._id, slot);
+          report.wiresAdded++;
+          touched = true;
+        }
+      }
+      if (touched || arrays.leadingSessions || arrays.observingSessions) {
+        await ctx.db.patch(s._id, {
+          leadingSessions: undefined,
+          observingSessions: undefined,
+        } as unknown as Partial<Doc<"students">>);
+        report.studentsStripped++;
+      }
+    }
+    for (const [id, slot] of pending) {
+      const sess = await ctx.db.get(id);
+      if (!sess) continue;
+      await ctx.db.patch(id, {
+        leaderIds: [...new Set([...sess.leaderIds, ...slot.leaderIds])],
+        observerIds: [
+          ...new Set([...sess.observerIds, ...slot.observerIds]),
+        ],
+      });
+    }
+    return report;
   },
 });

--- a/apps/roster/convex/schema.ts
+++ b/apps/roster/convex/schema.ts
@@ -21,12 +21,6 @@ export default defineSchema({
     // maintained at write time by recordAttendance / the backfill
     // migration (successor of the Airtable Missed formula).
     missed: v.number(),
-    // Legacy per-student assignment history (Airtable 主领日期/观察日期
-    // links plus the older scalar 带领日期/观察的日期, harmonized into
-    // these arrays by migrations:cleanupStudentFields). Assignment truth
-    // now lives on the sessions table.
-    leadingSessions: v.optional(v.array(v.string())),
-    observingSessions: v.optional(v.array(v.string())),
     // Optional registration photo (front-camera snap or gallery pick).
     photoStorageId: v.optional(v.id("_storage")),
   })

--- a/apps/roster/convex/students.ts
+++ b/apps/roster/convex/students.ts
@@ -55,15 +55,31 @@ export const byQuarter = query({
   },
 });
 
-// 带领经验: everyone with actual leading experience (帶過…).
+// 带领经验: everyone with actual leading experience (帶過…), enriched
+// with the class dates they led — derived from the sessions table
+// (leaderIds), the single source of assignment truth.
 export const withExperience = query({
   handler: async (ctx) => {
     await requireInstructor(ctx);
-    return (await ctx.db.query("students").collect()).filter(
+    const students = (await ctx.db.query("students").collect()).filter(
       (s) =>
         s.leadingExperience !== undefined &&
         s.leadingExperience !== "沒帶過",
     );
+    const byId = new Map(students.map((s) => [s._id, s]));
+    const dates = new Map<Id<"students">, string[]>();
+    for (const session of await ctx.db.query("sessions").collect()) {
+      for (const id of session.leaderIds) {
+        if (!byId.has(id)) continue;
+        const list = dates.get(id) ?? [];
+        list.push(session.date);
+        dates.set(id, list);
+      }
+    }
+    return students.map((s) => ({
+      ...s,
+      leadingDates: (dates.get(s._id) ?? []).sort(),
+    }));
   },
 });
 

--- a/apps/roster/src/Roster.tsx
+++ b/apps/roster/src/Roster.tsx
@@ -175,7 +175,7 @@ function ExperienceView() {
         ["名字", (s) => s.name, "serif"],
         ["團契", (s) => s.fellowship ?? ""],
         ["帶領經驗", (s) => s.leadingExperience ?? ""],
-        ["帶領日期", (s) => (s.leadingSessions ?? []).join("、"), "margin"],
+        ["帶領日期", (s) => (s.leadingDates ?? []).join("、"), "margin"],
       ]}
     />
   );


### PR DESCRIPTION
## Answer: no two-way link — one source + derive

A transactional two-way link (`sessions.leaderIds` ↔ `students.leadingSessions`) is possible in Convex but is duplicate state that drifts. The 主領/觀察 views already derive per-student dates by inverting the sessions table, so this PR makes that the whole story.

## Why reconciliation came first

A full consistency check showed the legacy arrays were **not** redundant: 80 leading + 88 observing stored dates were missing from the sessions side —
- 46+46 students wired in the arrays but absent from `leaderIds`/`observerIds` (import wiring gaps),
- 76 real class dates missing from the calendar entirely — **2023春季 ran Feb 26–Mar 19, 2024春季 Mar 3–24, 2026春季 Feb 8–Mar 1, 2025秋季 extended to Nov 9** — the April/October synthesized estimates were wrong, and these arrays held the real dates.

`migrations:reconcileAssignments` (idempotent) creates the 15 missing session rows (`estimated: true`), wires all 168 assignments into `leaderIds`/`observerIds`, then strips `leadingSessions`/`observingSessions` from every student. Zero information loss; one source of truth.

## Also

- 帶領經驗 view's 帶領日期 column now derives from `sessions.leaderIds` via `students:withExperience`.
- `verifyStudents` gains an `assignmentWires` counter.
- `transform_seed.py` no longer imports assignment fields; README updated.