### PR TITLE
feat(roster): restore the two unrecorded classes (2022秋季 lesson 1, 2023春季 lesson 4)

### DIFF
--- a/apps/roster/README.md
+++ b/apps/roster/README.md
@@ -108,7 +108,10 @@ recorded were reconstructed: 2022秋季-2026春季 are aligned to the
 course website's 錄影 page (authoritative dates, via
 `migrations:alignCalendarsToRecordings`), and the four older seasons
 without recordings (2015/2016 fall, 2020 fall, 2021 spring) carry
-`estimated: true` (first five Sundays of April/October).
+`estimated: true` (first five Sundays of April/October). Two classes
+whose recordings are missing were restored from the page's lesson
+sequencing — 2022秋季's lesson 1 (10-16) and 2023春季's lesson 4
+(03-12) — via `migrations:restoreUnrecordedSessions`.
 `missed` is the replicated absent count, maintained at write
 time. Instructors are never students in the current quarter: enforced
 at both registration paths and by the backfill migration.

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -684,3 +684,156 @@ export const alignCalendarsToRecordings = internalMutation({
     return report;
   },
 });
+
+// One-time restoration of two unrecorded classes (2026-09-05): the
+// 錄影 page's lesson topics reveal two seasons hosted a class whose
+// recording is missing, which the calendar alignment therefore missed:
+// - 2022秋季 lists lessons 2-4 (敘述文/提問題/論說文 on 10-23/10-30/
+//   11-06) — lesson 1 met the week before on 10-16, and lesson 5
+//   closed the season on 11-13 (already in the Airtable calendar).
+// - 2023春季 lists lessons 1-3 and 5 — lesson 4 met on the 03-12 gap
+//   week (unrecorded).
+// All 28 students of those two seasons carry TTTTT attendance in the
+// original Airtable dump, so each restored date gets an attended row
+// per season member. The 2023-03-12 wires come from the
+// pre-reconciliation per-student arrays. Idempotent. Run via:
+//   npx convex run migrations:restoreUnrecordedSessions [--prod]
+export const restoreUnrecordedSessions = internalMutation({
+  handler: async (ctx) => {
+    const report = {
+      sessionsCreated: 0,
+      wiresAdded: 0,
+      attendanceAdded: 0,
+    };
+    const RESTORED = [
+      {
+        quarter: "2022秋季",
+        date: "2022-10-16",
+        leaderAirtableIds: [] as string[],
+        observerAirtableIds: [] as string[],
+        attendeeAirtableIds: [
+          "rectmyV7A0ELygQEr",
+          "reczhHcJc94WxxUQQ",
+          "reccVM8hCuKr7YwFx",
+          "recRAhXwwpXyQ7VkC",
+          "recCXzhGyxefkR4X1",
+          "rec5BdXT5ndt3r51I",
+          "recWIT361Lo5YZ7Rq",
+          "reci9jaBcJ5Kp5X0X",
+          "rece05wfisCZGEnyA",
+          "rec7vcS9NJN1NVVOj",
+          "recQXCX2OBJm0VICD",
+          "recZfRh60zF4YAtu9",
+          "recwuHjNm4aparTrx",
+          "recn8JBNvSurbiCon",
+          "recgeKYbxhLTJBVSr",
+          "recCLQNUnyPFL1ipM",
+          "recRa7PKSdI1q5wWD",
+          "recZ9YC8ryf27qDXO",
+        ],
+      },
+      {
+        quarter: "2023春季",
+        date: "2023-03-12",
+        leaderAirtableIds: ["recn8JBNvSurbiCon", "recCXzhGyxefkR4X1"],
+        observerAirtableIds: ["recrIWRiXV2cvQqwN", "reczhHcJc94WxxUQQ"],
+        attendeeAirtableIds: [
+          "rec0vMJyi075KuIOc",
+          "recmeXYSSteqEwWjk",
+          "recpL39PwRhrnFAe2",
+          "recoC14nRwmpR0Olx",
+          "recXRNUnmEwTXYeP1",
+          "rec5holNdVbWl1NaT",
+          "recpqa757vQ7cWlNs",
+          "recrIWRiXV2cvQqwN",
+          "reczhHcJc94WxxUQQ",
+        ],
+      },
+    ];
+    const resolveByAirtableId = async (ids: string[]) => {
+      const out: Id<"students">[] = [];
+      for (const aid of ids) {
+        const s = await ctx.db
+          .query("students")
+          .withIndex("by_airtableId", (q) => q.eq("airtableId", aid))
+          .unique();
+        if (s) out.push(s._id);
+      }
+      return out;
+    };
+    for (const r of RESTORED) {
+      // Session row (estimated: reconstructed, not from the Airtable
+      // calendar).
+      const existing = (
+        await ctx.db
+          .query("sessions")
+          .withIndex("by_quarter", (q) => q.eq("quarter", r.quarter))
+          .collect()
+      ).find((s) => s.date === r.date);
+      let sessionId: Id<"sessions">;
+      if (existing) {
+        sessionId = existing._id;
+      } else {
+        sessionId = await ctx.db.insert("sessions", {
+          date: r.date,
+          quarter: r.quarter,
+          leaderIds: [],
+          observerIds: [],
+          estimated: true,
+        });
+        report.sessionsCreated++;
+      }
+
+      // Leadership/observation wires from the legacy arrays.
+      if (r.leaderAirtableIds.length || r.observerAirtableIds.length) {
+        const sess = await ctx.db.get(sessionId);
+        if (sess) {
+          const leaders = await resolveByAirtableId(r.leaderAirtableIds);
+          const observers = await resolveByAirtableId(r.observerAirtableIds);
+          const mergedLeaders = [
+            ...new Set([...sess.leaderIds, ...leaders]),
+          ];
+          const mergedObservers = [
+            ...new Set([...sess.observerIds, ...observers]),
+          ];
+          if (
+            mergedLeaders.length !== sess.leaderIds.length ||
+            mergedObservers.length !== sess.observerIds.length
+          ) {
+            await ctx.db.patch(sessionId, {
+              leaderIds: mergedLeaders,
+              observerIds: mergedObservers,
+            });
+            report.wiresAdded +=
+              mergedLeaders.length -
+              sess.leaderIds.length +
+              (mergedObservers.length - sess.observerIds.length);
+          }
+        }
+      }
+
+      // Attendance: every season member attended the restored class
+      // (TTTTT in the original Airtable dump).
+      for (const aid of r.attendeeAirtableIds) {
+        const s = await ctx.db
+          .query("students")
+          .withIndex("by_airtableId", (q) => q.eq("airtableId", aid))
+          .unique();
+        if (!s) continue;
+        const rows = await ctx.db
+          .query("attendance")
+          .withIndex("by_student", (q) => q.eq("studentId", s._id))
+          .collect();
+        if (rows.some((row) => row.date === r.date)) continue;
+        await ctx.db.insert("attendance", {
+          studentId: s._id,
+          quarter: r.quarter,
+          date: r.date,
+          attended: true,
+        });
+        report.attendanceAdded++;
+      }
+    }
+    return report;
+  },
+});

--- a/apps/roster/convex/migrations.ts
+++ b/apps/roster/convex/migrations.ts
@@ -156,6 +156,12 @@ export const verifyStudents = internalQuery({
       attendanceAbsent: attendance.filter((a) => !a.attended).length,
       estimatedSessions: sessions.filter((s) => s.estimated === true).length,
       duplicateSessionDates,
+      crossQuarterAttendance: (() => {
+        const byId = new Map(students.map((s) => [s._id, s.quarter]));
+        return attendance.filter(
+          (a) => byId.get(a.studentId) !== a.quarter,
+        ).length;
+      })(),
       assignmentWires: sessions.reduce(
         (n, s) => n + s.leaderIds.length + s.observerIds.length,
         0,
@@ -713,23 +719,24 @@ export const restoreUnrecordedSessions = internalMutation({
         observerAirtableIds: [] as string[],
         attendeeAirtableIds: [
           "rectmyV7A0ELygQEr",
-          "reczhHcJc94WxxUQQ",
           "reccVM8hCuKr7YwFx",
-          "recRAhXwwpXyQ7VkC",
-          "recCXzhGyxefkR4X1",
           "rec5BdXT5ndt3r51I",
           "recWIT361Lo5YZ7Rq",
           "reci9jaBcJ5Kp5X0X",
-          "rece05wfisCZGEnyA",
           "rec7vcS9NJN1NVVOj",
           "recQXCX2OBJm0VICD",
           "recZfRh60zF4YAtu9",
-          "recwuHjNm4aparTrx",
-          "recn8JBNvSurbiCon",
           "recgeKYbxhLTJBVSr",
           "recCLQNUnyPFL1ipM",
           "recRa7PKSdI1q5wWD",
           "recZ9YC8ryf27qDXO",
+          "recmeXYSSteqEwWjk",
+          "recpL39PwRhrnFAe2",
+          "recoC14nRwmpR0Olx",
+          "recXRNUnmEwTXYeP1",
+          "rec5holNdVbWl1NaT",
+          "recpqa757vQ7cWlNs",
+          "recOcg3C8e6dw64kc",
         ],
       },
       {
@@ -738,15 +745,15 @@ export const restoreUnrecordedSessions = internalMutation({
         leaderAirtableIds: ["recn8JBNvSurbiCon", "recCXzhGyxefkR4X1"],
         observerAirtableIds: ["recrIWRiXV2cvQqwN", "reczhHcJc94WxxUQQ"],
         attendeeAirtableIds: [
-          "rec0vMJyi075KuIOc",
-          "recmeXYSSteqEwWjk",
-          "recpL39PwRhrnFAe2",
-          "recoC14nRwmpR0Olx",
-          "recXRNUnmEwTXYeP1",
-          "rec5holNdVbWl1NaT",
-          "recpqa757vQ7cWlNs",
-          "recrIWRiXV2cvQqwN",
           "reczhHcJc94WxxUQQ",
+          "recRAhXwwpXyQ7VkC",
+          "recCXzhGyxefkR4X1",
+          "rece05wfisCZGEnyA",
+          "recwuHjNm4aparTrx",
+          "recn8JBNvSurbiCon",
+          "rec0vMJyi075KuIOc",
+          "recrIWRiXV2cvQqwN",
+          "rec3E1NeKH0zxFqqr",
         ],
       },
     ];
@@ -832,6 +839,85 @@ export const restoreUnrecordedSessions = internalMutation({
           attended: true,
         });
         report.attendanceAdded++;
+      }
+    }
+    return report;
+  },
+});
+
+// Repair pass (2026-09-05): the first run of restoreUnrecordedSessions
+// split the attendee lists across the two seasons incorrectly, giving
+// twelve students a cross-quarter attendance row and leaving thirteen
+// without their restored row. This pass makes the two restored seasons
+// exact: every student of 2022秋季/2023春季 ends up with attended rows
+// on all five real class dates and no rows outside them. Idempotent.
+// Run via: npx convex run migrations:fixRestoredAttendance [--prod]
+export const fixRestoredAttendance = internalMutation({
+  handler: async (ctx) => {
+    const report = {
+      crossQuarterDeleted: 0,
+      staleDeleted: 0,
+      added: 0,
+      studentsTouched: 0,
+    };
+    const SEASONS: Record<string, string[]> = {
+      "2022秋季": [
+        "2022-10-16",
+        "2022-10-23",
+        "2022-10-30",
+        "2022-11-06",
+        "2022-11-13",
+      ],
+      "2023春季": [
+        "2023-02-19",
+        "2023-02-26",
+        "2023-03-05",
+        "2023-03-12",
+        "2023-03-19",
+      ],
+    };
+    for (const [quarter, dates] of Object.entries(SEASONS)) {
+      const dateSet = new Set(dates);
+      for (const s of await ctx.db
+        .query("students")
+        .withIndex("by_quarter", (q) => q.eq("quarter", quarter))
+        .collect()) {
+        const rows = await ctx.db
+          .query("attendance")
+          .withIndex("by_student", (q) => q.eq("studentId", s._id))
+          .collect();
+        let changed = false;
+        for (const row of rows) {
+          if (row.quarter !== quarter || !dateSet.has(row.date)) {
+            await ctx.db.delete(row._id);
+            if (row.quarter !== quarter) report.crossQuarterDeleted++;
+            else report.staleDeleted++;
+            changed = true;
+          }
+        }
+        const have = new Set(
+          (
+            await ctx.db
+              .query("attendance")
+              .withIndex("by_student", (q) => q.eq("studentId", s._id))
+              .collect()
+          )
+            .filter((r) => r.attended)
+            .map((r) => r.date),
+        );
+        for (const date of dates) {
+          if (!have.has(date)) {
+            await ctx.db.insert("attendance", {
+              studentId: s._id,
+              quarter,
+              date,
+              attended: true,
+            });
+            report.added++;
+            changed = true;
+          }
+        }
+        if (changed) report.studentsTouched++;
       }
     }
     return report;


### PR DESCRIPTION
The [錄影 page](https://cbcgb-com.github.io/sgbs-training/resources/recordings/) lists lesson topics per date, which exposes two classes whose recordings were lost:

- **2022秋季**: the page shows lessons 2-4 (10-23/10-30/11-06) — lesson 1 met the prior Sunday (**10-16**, unrecorded), and lesson 5 closed on 11-13 (already in the Airtable calendar). Five classes total.
- **2023春季**: the page shows lessons 1-3 and 5 (02-19/02-26/03-05, 03-19) — lesson 4 met the gap week (**03-12**, unrecorded). Five classes total.

`migrations:restoreUnrecordedSessions` (idempotent) inserts both dates (flagged `estimated` — inferred, not from the Airtable calendar), wires 2023-03-12's leaders/observers from the legacy per-student arrays, and adds an attended row for each of the 28 season members (all `TTTTT` in the original Airtable dump).