### PR TITLE
Fix Safari scroll trap over roster tables + seed preview grouping data

### DIFF
--- a/apps/roster/convex/demo.ts
+++ b/apps/roster/convex/demo.ts
@@ -24,9 +24,10 @@ const FAKE_STUDENTS = [
 ];
 
 // 2026秋季 Sunday schedule. Dates that already exist are patched with the
-// extra assignments rather than duplicated.
+// extra assignments rather than duplicated. The first class of the season
+// (2026-09-20, 課程信息介紹) is deliberately absent — orientation never
+// carries 主領/觀察; only the four leading weeks appear here.
 const FAKE_SESSIONS = [
-  { date: "2026-09-20", leaderEmails: ["demo1@demo.sgbs"], observerEmails: ["demo4@demo.sgbs", "demo7@demo.sgbs"] },
   { date: "2026-09-27", leaderEmails: ["demo5@demo.sgbs", "demo2@demo.sgbs"], observerEmails: ["demo8@demo.sgbs"] },
   { date: "2026-10-04", leaderEmails: ["demo6@demo.sgbs"], observerEmails: ["demo3@demo.sgbs", "demo5@demo.sgbs"] },
   { date: "2026-10-11", leaderEmails: ["demo4@demo.sgbs", "demo7@demo.sgbs"], observerEmails: ["demo1@demo.sgbs"] },
@@ -118,6 +119,61 @@ export const seedPreviewDemo = internalMutation({  handler: async (ctx) => {
     }
 
     return { studentsAdded, sessionsAdded };
+  },
+});
+
+// 15 ungrouped test registrations (2026-09-05): fake students for testing
+// the instructor grouping flow. No groupName — the divider starts from a
+// fully unassigned pool. Run via
+//   npx convex run demo:seedUngroupedStudents
+// Safe to re-run: matched by email, students already registered this
+// quarter are left untouched.
+const UNGROUPED_STUDENTS = [
+  { name: "林嘉豪", email: "demo10@demo.sgbs", fellowship: "MIT團契（工作組之一）", gender: "男", baptismTime: "超過5年", leadingExperience: "帶過，多於5次" },
+  { name: "黃詩敏", email: "demo11@demo.sgbs", fellowship: "樂河團契", gender: "女", baptismTime: "1到5年", leadingExperience: "沒帶過" },
+  { name: "張雅雯", email: "demo12@demo.sgbs", fellowship: "Longwood 團契", gender: "女", baptismTime: "少於1年", leadingExperience: "沒帶過" },
+  { name: "李志強", email: "demo13@demo.sgbs", fellowship: "Malden 團契", gender: "男", baptismTime: "超過5年", leadingExperience: "帶過，1到5次" },
+  { name: "陳美恩", email: "demo14@demo.sgbs", fellowship: "學生團契（研究生）", gender: "女", baptismTime: "1到5年", leadingExperience: "帶過，1到5次" },
+  { name: "周天樂", email: "demo15@demo.sgbs", fellowship: "學生團契（本科生）", gender: "男", baptismTime: "少於1年", leadingExperience: "沒帶過" },
+  { name: "許文靜", email: "demo16@demo.sgbs", fellowship: "MIT團契（學生組）", gender: "女", baptismTime: "1到5年", leadingExperience: "沒帶過" },
+  { name: "王守信", email: "demo17@demo.sgbs", fellowship: "樂河團契", gender: "男", baptismTime: "超過5年", leadingExperience: "帶過，多於5次" },
+  { name: "葉恩慈", email: "demo18@demo.sgbs", fellowship: "其他", gender: "女", baptismTime: "少於1年", leadingExperience: "沒帶過" },
+  { name: "蔡明軒", email: "demo19@demo.sgbs", fellowship: "Longwood 團契", gender: "男", baptismTime: "1到5年", leadingExperience: "帶過，1到5次" },
+  { name: "羅以琳", email: "demo20@demo.sgbs", fellowship: "Malden 團契", gender: "女", baptismTime: "超過5年", leadingExperience: "沒帶過" },
+  { name: "楊約翰", email: "demo21@demo.sgbs", fellowship: "MIT團契（工作組之一）", gender: "男", baptismTime: "1到5年", leadingExperience: "帶過，多於5次" },
+  { name: "許佳音", email: "demo22@demo.sgbs", fellowship: "學生團契（研究生）", gender: "女", baptismTime: "少於1年", leadingExperience: "沒帶過" },
+  { name: "馮保羅", email: "demo23@demo.sgbs", fellowship: "其他", gender: "男", baptismTime: "超過5年", leadingExperience: "帶過，1到5次" },
+  { name: "鄧曉琳", email: "demo24@demo.sgbs", fellowship: "樂河團契", gender: "女", baptismTime: "1到5年", leadingExperience: "帶過，1到5次" },
+];
+
+export const seedUngroupedStudents = internalMutation({
+  handler: async (ctx) => {
+    let added = 0;
+    const skipped: string[] = [];
+    for (const s of UNGROUPED_STUDENTS) {
+      const existing = await ctx.db
+        .query("students")
+        .withIndex("by_email", (q) => q.eq("email", s.email))
+        .collect();
+      if (existing.find((e) => e.quarter === CURRENT_QUARTER)) {
+        skipped.push(s.name);
+        continue;
+      }
+      await ctx.db.insert("students", {
+        name: s.name,
+        email: s.email,
+        fellowship: s.fellowship,
+        gender: s.gender,
+        baptismTime: s.baptismTime,
+        leadingExperience: s.leadingExperience,
+        quarter: CURRENT_QUARTER,
+        present: true,
+        missed: 0,
+        // No groupName: the instructor assigns groups later.
+      });
+      added++;
+    }
+    return { added, skipped };
   },
 });
 

--- a/apps/roster/src/Directory.tsx
+++ b/apps/roster/src/Directory.tsx
@@ -67,7 +67,7 @@ export default function Directory({
           本季度尚無記錄
         </p>
       ) : (
-        <div className="mt-2 overflow-x-auto">
+        <div className="mt-2 overflow-x-auto overflow-y-clip">
           <table className="w-full border-collapse text-left text-base tabular-nums">
             <thead>
               <tr className="border-b-2 border-ink">

--- a/apps/roster/src/Roster.tsx
+++ b/apps/roster/src/Roster.tsx
@@ -322,7 +322,7 @@ function Kanban({
   if (!groups) return <Loading />;
   const sorted = [...groups].sort((a, b) => b.count - a.count);
   return (
-    <div className="flex gap-5 overflow-x-auto pb-4">
+    <div className="flex gap-5 overflow-x-auto overflow-y-clip pb-4">
       {sorted.map((g) => (
         <section key={g.value} className="w-60 shrink-0">
           <header className="flex items-baseline justify-between border-b-2 border-ink pb-2">
@@ -405,7 +405,7 @@ function StudentTable<
     );
   }
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto overflow-y-clip">
       <table className="w-full border-collapse text-left text-base tabular-nums">
         <thead>
           <tr className="border-b-2 border-ink">

--- a/apps/roster/src/ScheduleView.tsx
+++ b/apps/roster/src/ScheduleView.tsx
@@ -158,7 +158,7 @@ function GroupScheduleTable({
           {members.length} 位
         </span>
       </div>
-      <div className="mt-2 overflow-x-auto">
+      <div className="mt-2 overflow-x-auto overflow-y-clip">
         <table className="w-full border-collapse text-left text-base">
           <thead>
             <tr className="border-b-2 border-ink">
@@ -367,7 +367,7 @@ function StudentSchedule({ sessions }: { sessions: SessionRow[] }) {
           {error}
         </p>
       )}
-      <div className="mt-4 overflow-x-auto">
+      <div className="mt-4 overflow-x-auto overflow-y-clip">
         <table className="w-full border-collapse text-left text-base">
           <thead>
             <tr className="border-b-2 border-ink">


### PR DESCRIPTION
## What

Two independent roster fixes, both verified on the dev (preview) deployment `rugged-oriole-958`:

### 1. Page scroll dead over tables in Safari

Cursor over the 名單 table = two-finger scroll swallowed; cursor outside = page scrolls.

Root cause: the table wrappers used Tailwind `overflow-x-auto` alone. CSS forbids `overflow-x: auto` with `overflow-y: visible`, so the browser silently computes the vertical axis to `auto` — the wrapper becomes a scroll container in BOTH axes. On WebKit, that trap can lock a vertical trackpad gesture instead of passing it to the page.

Fix: pair every horizontal-scroll wrapper with `overflow-y-clip` (the one value that scrolls neither axis and pairs legally with `overflow-x: auto`). Horizontal scrolling inside the wrapper is untouched.

Applied to all 5 wrappers: roster table + kanban (Roster.tsx), 聯絡表 (Directory.tsx), both 課堂安排 tables (ScheduleView.tsx).

### 2. Preview seeding for the instructor grouping flow

- `demo:seedUngroupedStudents` (convex/demo.ts): 15 fake 2026秋季 students, no `groupName` — the 分組 flow starts from a fully unassigned pool. Re-run safe (matched by email).
- Existing demo/test students' stale 第1組/第2組/第3組 assignments and attendance were cleared via the existing `demo:resetQuarterData` before seeding: dev backend now holds 26 ungrouped current-quarter students, 0 attendance rows.
- Removed the 2026-09-20 (課程信息介紹, orientation) leading/observing assignments from `FAKE_SESSIONS` — the first class never carries 主領/觀察; the old seed contradicted the file's own rule. Live dev data fixed via `demo:deleteSessionByDate`.

## Verification

- Typecheck passes (`tsc --noEmit`).
- WebKit engine repro (Playwright): before fix the wrapper computed `auto/auto` and trapped; after fix it computes `auto/hidden`, page scroll over the table matches scroll outside it (300 == 300 px), horizontal wheel scroll inside the wrapper still works.
- Seeded dev data verified via inline queries: 26/26 ungrouped, 0 attendance rows, orientation session deleted, remaining 4 leading weeks intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
