### PR TITLE
Hide claim/assign controls on orientation week in 課堂安排

### DIFF
--- a/apps/roster/convex/demo.ts
+++ b/apps/roster/convex/demo.ts
@@ -203,7 +203,28 @@ export const resetQuarterData = internalMutation({
 });
 
 // The first class of a season is orientation (課程信息介紹) — it never has
-// 主領/觀察. Each season only carries four leading weeks. Run via
+// 主領/觀察. Ensure its session row exists (empty assignments) so the
+// schedule shows the full five-Sunday calendar. Run via
+//   npx convex run demo:ensureOrientationSession
+export const ensureOrientationSession = internalMutation({
+  handler: async (ctx) => {
+    const date = CURRENT_QUARTER_SESSION_DATES[0];
+    const existing = (await ctx.db.query("sessions").collect()).find(
+      (x) => x.date === date && x.quarter === CURRENT_QUARTER,
+    );
+    if (existing) return { status: "exists" as const };
+    await ctx.db.insert("sessions", {
+      date,
+      quarter: CURRENT_QUARTER,
+      leaderIds: [],
+      observerIds: [],
+    });
+    return { status: "created" as const };
+  },
+});
+
+// One-off cleanup: delete a session row by date (e.g. a mis-seeded
+// orientation assignment). Run via
 // `npx convex run demo:deleteSessionByDate '{"date":"2026-09-13"}'`.
 export const deleteSessionByDate = internalMutation({
   args: { date: v.string() },

--- a/apps/roster/src/ScheduleView.tsx
+++ b/apps/roster/src/ScheduleView.tsx
@@ -50,10 +50,18 @@ export default function ScheduleView({ isInstructor }: { isInstructor: boolean }
     );
   }
 
-  if (!isInstructor) {
-    return <StudentSchedule sessions={sessions} />;
-  }
+  // The earliest date of the season is orientation week (課程信息介紹):
+  // it never carries 主領/觀察, in either view.
+  const orientationDate = sessions[0]?.date ?? null;
 
+  if (!isInstructor) {
+    return (
+      <StudentSchedule
+        sessions={sessions}
+        orientationDate={orientationDate}
+      />
+    );
+  }
 
   return (
     <div>
@@ -68,7 +76,11 @@ export default function ScheduleView({ isInstructor }: { isInstructor: boolean }
       <p className="mt-3 text-sm leading-relaxed text-ink-soft">
         按小組填寫每週的主領與觀察；日期已固定，每組輪流服事。
       </p>
-      <GroupSections sessions={sessions} roster={roster ?? []} />
+      <GroupSections
+        sessions={sessions}
+        roster={roster ?? []}
+        orientationDate={orientationDate}
+      />
     </div>
   );
 }
@@ -76,9 +88,11 @@ export default function ScheduleView({ isInstructor }: { isInstructor: boolean }
 function GroupSections({
   sessions,
   roster,
+  orientationDate,
 }: {
   sessions: SessionRow[];
   roster: Doc<"students">[];
+  orientationDate: string | null;
 }) {
   const named = useMemo(() => {
     const map = new Map<string, Doc<"students">[]>();
@@ -107,6 +121,7 @@ function GroupSections({
           groupName={name}
           members={members}
           sessions={sessions}
+          orientationDate={orientationDate}
         />
       ))}
       {named.ungrouped.length > 0 && (
@@ -114,6 +129,7 @@ function GroupSections({
           groupName="未分組"
           members={named.ungrouped}
           sessions={sessions}
+          orientationDate={orientationDate}
         />
       )}
     </div>
@@ -124,10 +140,12 @@ function GroupScheduleTable({
   groupName,
   members,
   sessions,
+  orientationDate,
 }: {
   groupName: string;
   members: Doc<"students">[];
   sessions: SessionRow[];
+  orientationDate: string | null;
 }) {
   const assign = useMutation(api.students.updateSessionAssignments);
   const memberIds = useMemo(() => new Set(members.map((m) => m._id)), [members]);
@@ -188,6 +206,24 @@ function GroupScheduleTable({
               const weekday = [
                 "日", "一", "二", "三", "四", "五", "六",
               ][dateObj.getDay()];
+              if (s.date === orientationDate) {
+                return (
+                  <tr key={s._id} className="border-b border-rule">
+                    <td className="whitespace-nowrap px-3 py-3 align-top font-serif-tc text-[15px] font-bold text-ink">
+                      {s.date.slice(5)}
+                      <span className="ml-1.5 text-xs font-normal text-ink-soft">
+                        週{weekday}
+                      </span>
+                    </td>
+                    <td
+                      colSpan={2}
+                      className="px-3 py-3 font-serif-tc text-sm text-ink-soft"
+                    >
+                      課程信息介紹 — 本週無主領觀察
+                    </td>
+                  </tr>
+                );
+              }
               return (
                 <tr
                   key={s._id}
@@ -312,7 +348,13 @@ function roleLabel(role: Role) {
 }
 
 
-function StudentSchedule({ sessions }: { sessions: SessionRow[] }) {
+function StudentSchedule({
+  sessions,
+  orientationDate,
+}: {
+  sessions: SessionRow[];
+  orientationDate: string | null;
+}) {
   const { setTab } = useTab();
   const me = useQuery(api.students.me);
   const group = useQuery(api.students.myGroup);
@@ -397,6 +439,24 @@ function StudentSchedule({ sessions }: { sessions: SessionRow[] }) {
               const weekday = [
                 "日", "一", "二", "三", "四", "五", "六",
               ][dateObj.getDay()];
+              if (s.date === orientationDate) {
+                return (
+                  <tr key={s._id} className="border-b border-rule">
+                    <td className="whitespace-nowrap px-3 py-3 align-top font-serif-tc text-[17px] font-bold text-ink">
+                      {s.date}
+                      <span className="ml-2 text-sm font-normal text-ink-soft">
+                        週{weekday}
+                      </span>
+                    </td>
+                    <td
+                      colSpan={2}
+                      className="px-3 py-3 font-serif-tc text-sm text-ink-soft"
+                    >
+                      課程信息介紹 — 本週無主領觀察
+                    </td>
+                  </tr>
+                );
+              }
               const iLead = myId !== null && s.leaders.some((l) => l._id === myId);
               const iObserve =
                 myId !== null && s.observers.some((o) => o._id === myId);


### PR DESCRIPTION
## What

課程信息介紹 (the first class of the season) never carries 主領/觀察 — but the schedule still rendered interactive controls for that week:

- **Student view**: 我來主領 / 我來觀察 claim buttons were clickable on the orientation row.
- **Instructor view**: + 添加 dropdowns allowed assigning people to that week.

## Fix

`ScheduleView` derives `orientationDate` = the earliest session date of the current season and threads it into both `GroupScheduleTable` (instructor) and `StudentSchedule`. The orientation row renders as a merged plain-text cell「課程信息介紹 — 本週無主領觀察」— no claim buttons, no add dropdowns, in either view.

## Also

`demo:ensureOrientationSession` (convex/demo.ts) inserts the empty 2026-09-20 session row if missing, so the five-Sunday calendar always renders after demo resets (the earlier delete-only cleanup left the season one row short).

## Verification

- `tsc --noEmit` clean.
- Proven live across three real-Chrome phone-sized windows (instructor + student 林嘉豪 + classmate 黃詩敏): orientation row renders plain in all three; the real-time claim/rename sync demo ran against this exact code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
