### PR TITLE
docs(landing): lead with registration, reframe QR section as sharing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,15 +10,14 @@
 ### 報名
 
 2026年秋季課程現正接受報名。
-
-<a class="register-cta" href="https://sgbs-training.citylight.life">前往報名</a>
+點擊二維碼，或用手機掃描，即可前往報名表。
 
 <div class="qrcode-options qrcode-options--single">
 
 <div class="qrcode-option">
 <p class="qrcode-option__title">報名二維碼</p>
-<p class="qrcode-option__hint">讓身旁的人直接掃描進入報名表；點擊二維碼也可以報名。</p>
-<a class="qrcode-option__qr-link" href="https://sgbs-training.citylight.life"><img src="./images/registration-qrcode.png" alt="報名二維碼" width="140" height="140"></a>
+<p class="qrcode-option__hint">讓身旁的人也可以直接掃描報名。</p>
+<a class="qrcode-option__qr-link" href="https://sgbs-training.citylight.life" aria-label="點擊前往報名表"><img src="./images/registration-qrcode.png" alt="報名二維碼" width="140" height="140"><span class="tap-hint" aria-hidden="true"><svg class="tap-hint__cursor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M5 2.5 L5 19 L9.2 15.3 L11.7 20.6 L14.4 19.4 L11.9 14.2 L17 13.7 Z" fill="#ffffff" stroke="#262116" stroke-width="1.4" stroke-linejoin="round"/></svg><svg class="tap-hint__finger" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M9 11.24V7.5C9 6.12 10.12 5 11.5 5S14 6.12 14 7.5v3.74c1.21-.81 2-2.18 2-3.74C16 5.01 13.99 3 11.5 3S7 5.01 7 7.5c0 1.56.79 2.93 2 3.74zm9.84 4.63l-4.54-2.26c-.17-.07-.35-.11-.54-.11H13v-6c0-.83-.67-1.5-1.5-1.5S10 6.67 10 7.5v10.74l-3.43-.72c-.08-.01-.15-.03-.24-.03-.31 0-.59.13-.79.33l-.79.8 4.94 4.94c.27.27.65.44 1.06.44h6.79c.75 0 1.33-.55 1.44-1.28l.75-5.27c.01-.07.02-.14.02-.2 0-.62-.38-1.16-.91-1.38z" fill="#ffffff" stroke="#262116" stroke-width="0.8" stroke-linejoin="round"/></svg><span class="tap-hint__ripple"></span></span></a>
 </div>
 
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,26 +7,11 @@
 我們期待看到您在這方面的成長。
 願這個網頁成為您的資源，更成為您的祝福！
 
-### 二維碼
+### 報名
 
-依你的需要選一個掃描：
+2026年秋季課程現正接受報名。
 
-<div class="qrcode-options">
-
-<div class="qrcode-option">
-<p class="qrcode-option__title">進入課程網頁</p>
-<p class="qrcode-option__hint">分享此頁給別人，或自己瀏覽講義與資源時用。進入後可再點擊報名連結。</p>
-<img src="./images/website-qrcode.png" alt="課程網頁二維碼" width="140" height="140">
-</div>
-
-<div class="qrcode-option">
-<p class="qrcode-option__title">直接報名</p>
-<p class="qrcode-option__hint">現場讓人直接掃描報名時用。</p>
-<img src="./images/registration-qrcode.png" alt="報名二維碼" width="140" height="140">
-<p class="qrcode-option__link"><a href="https://sgbs-training.citylight.life">或點此連結報名</a></p>
-</div>
-
-</div>
+<a class="register-cta" href="https://sgbs-training.citylight.life">前往報名</a>
 
 <!-- 本季課堂已停止接受註冊，請等到下一季課堂開放再註冊。-->
 
@@ -47,7 +32,7 @@
 
 <!-- 疫情期間，我們的課堂會在Discord上進行。 -->
 
-2026年春季課程將在線下舉行，2月1日開始，共五週，在CBCGB城光堂三樓聚會。
+2026年秋季課程將在線下舉行，9月20日開始，共五週，在CBCGB城光堂三樓聚會。
 
 ### 出席要求
 
@@ -169,3 +154,19 @@
 
 - [YouTube頻道](https://www.youtube.com/user/jointhebibleproject/)
 - [網站](https://bibleproject.com)
+
+## 分享這門課
+
+把這個畫面給身旁的弟兄姊妹掃一掃，邀請他們一起來學習帶領查經，
+掃描後就能進入本頁查看課程信息並報名。
+不方便掃描時，也可以直接分享網址：[cbcgb-com.github.io/sgbs-training](https://cbcgb-com.github.io/sgbs-training/)
+
+<div class="qrcode-options qrcode-options--single">
+
+<div class="qrcode-option">
+<p class="qrcode-option__title">課程網頁二維碼</p>
+<p class="qrcode-option__hint">進入後可查看上課時間、講義資源與報名連結。</p>
+<img src="./images/website-qrcode.png" alt="課程網頁二維碼" width="140" height="140">
+</div>
+
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,16 @@
 
 <a class="register-cta" href="https://sgbs-training.citylight.life">前往報名</a>
 
+<div class="qrcode-options qrcode-options--single">
+
+<div class="qrcode-option">
+<p class="qrcode-option__title">報名二維碼</p>
+<p class="qrcode-option__hint">讓身旁的人直接掃描進入報名表；點擊二維碼也可以報名。</p>
+<a class="qrcode-option__qr-link" href="https://sgbs-training.citylight.life"><img src="./images/registration-qrcode.png" alt="報名二維碼" width="140" height="140"></a>
+</div>
+
+</div>
+
 <!-- 本季課堂已停止接受註冊，請等到下一季課堂開放再註冊。-->
 
 ## 課程信息

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1115,46 +1115,6 @@ article.typography table tbody tr:hover,
 }
 
 /*
- * Landing registration CTA – the one prominent action on the home page.
- * Vermilion seal-style fill; ghost-on-hover like the ledger buttons.
- * Scoped to .typography a to outrank the global link styling.
- */
-.typography a.register-cta {
-    display: inline-block;
-    padding: 0.6rem 1.75rem;
-    font-family: "Noto Serif TC", "Songti TC", "SimSun", serif;
-    font-size: 1.05em;
-    font-weight: 700;
-    letter-spacing: 0.14em;
-    color: var(--sgbs-paper);
-    background: var(--sgbs-vermilion);
-    border: 1px solid var(--sgbs-vermilion);
-    border-radius: 6px;
-    text-decoration: none;
-    transition: background 0.15s ease, color 0.15s ease,
-        border-color 0.15s ease;
-    -webkit-tap-highlight-color: transparent;
-}
-
-.typography a.register-cta:hover,
-.typography a.register-cta:focus-visible {
-    color: var(--sgbs-vermilion);
-    background: transparent;
-    text-decoration: none;
-}
-
-.typography a.register-cta:focus-visible {
-    outline: 2px solid var(--sgbs-vermilion);
-    outline-offset: 2px;
-}
-
-/* A hair lighter than --sgbs-vermilion so paper-dark text keeps AA. */
-.dark .typography a.register-cta {
-    background: #d4603f;
-    border-color: #d4603f;
-}
-
-/*
  * QR share card – a single card for handing the page to someone else.
  * (Two QRs side by side read as "scan one of these," which made no
  * sense on the page itself; registration now leads as a text CTA.)
@@ -1177,7 +1137,143 @@ article.typography table tbody tr:hover,
 /* Clickable QR image: no link chrome, gentle hover/focus cue. */
 .typography a.qrcode-option__qr-link {
     display: inline-block;
+    position: relative;
     text-decoration: none;
+}
+
+/*
+ * First-load tap hint: a cursor (mouse) or finger (touch) nudges in
+ * from the corner, taps the QR a few times, then fades for good.
+ * The icon swaps on input modality; reduced-motion users never see
+ * it, and hovering/focusing the QR dismisses it immediately.
+ */
+.tap-hint {
+    position: absolute;
+    right: 4px;
+    bottom: 2px;
+    width: 30px;
+    height: 30px;
+    pointer-events: none;
+    opacity: 0;
+    animation: tap-hint-move 1.9s ease-in-out 0.4s 3 both;
+}
+
+.tap-hint svg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.35));
+}
+
+.tap-hint__cursor {
+    display: block;
+}
+
+.tap-hint__finger {
+    display: none;
+}
+
+/* Touch screens get the finger; mouse-driven pointers get the cursor. */
+@media (hover: none), (pointer: coarse) {
+    .tap-hint__cursor {
+        display: none;
+    }
+
+    .tap-hint__finger {
+        display: block;
+    }
+}
+
+.tap-hint__ripple {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 34px;
+    height: 34px;
+    margin: -17px 0 0 -17px;
+    border-radius: 50%;
+    border: 2px solid var(--sgbs-vermilion);
+    opacity: 0;
+    animation: tap-hint-ripple 1.9s ease-out 0.4s 3 both;
+}
+
+@keyframes tap-hint-move {
+    0% {
+        transform: translate(0, 0) scale(1);
+        opacity: 0;
+    }
+
+    12% {
+        opacity: 1;
+    }
+
+    45% {
+        transform: translate(-51px, -53px) scale(0.88);
+        opacity: 1;
+    }
+
+    54% {
+        transform: translate(-51px, -53px) scale(1);
+        opacity: 1;
+    }
+
+    62% {
+        transform: translate(-51px, -53px) scale(0.88);
+        opacity: 1;
+    }
+
+    82% {
+        transform: translate(-51px, -53px) scale(0.88);
+        opacity: 1;
+    }
+
+    100% {
+        transform: translate(-51px, -53px) scale(0.88);
+        opacity: 0;
+    }
+}
+
+@keyframes tap-hint-ripple {
+    0%,
+    48% {
+        opacity: 0;
+        transform: scale(0.35);
+    }
+
+    55% {
+        opacity: 0.9;
+        transform: scale(0.45);
+    }
+
+    80% {
+        opacity: 0;
+        transform: scale(1.2);
+    }
+
+    100% {
+        opacity: 0;
+        transform: scale(1.2);
+    }
+}
+
+/* Any attention on the QR itself dismisses the hint right away. */
+.typography a.qrcode-option__qr-link:hover .tap-hint,
+.typography a.qrcode-option__qr-link:focus-visible .tap-hint {
+    animation: none;
+    opacity: 0;
+}
+
+.typography a.qrcode-option__qr-link:hover .tap-hint__ripple,
+.typography a.qrcode-option__qr-link:focus-visible .tap-hint__ripple {
+    animation: none;
+    opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .tap-hint {
+        display: none;
+    }
 }
 
 .typography a.qrcode-option__qr-link:hover img,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1174,6 +1174,17 @@ article.typography table tbody tr:hover,
     margin-right: auto;
 }
 
+/* Clickable QR image: no link chrome, gentle hover/focus cue. */
+.typography a.qrcode-option__qr-link {
+    display: inline-block;
+    text-decoration: none;
+}
+
+.typography a.qrcode-option__qr-link:hover img,
+.typography a.qrcode-option__qr-link:focus-visible img {
+    opacity: 0.8;
+}
+
 .qrcode-option {
     border: 1px solid var(--border, rgba(0, 0, 0, 0.12));
     border-radius: 10px;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1115,13 +1115,63 @@ article.typography table tbody tr:hover,
 }
 
 /*
- * QR code options – two clear cards so "which QR?" is obvious.
+ * Landing registration CTA – the one prominent action on the home page.
+ * Vermilion seal-style fill; ghost-on-hover like the ledger buttons.
+ * Scoped to .typography a to outrank the global link styling.
+ */
+.typography a.register-cta {
+    display: inline-block;
+    padding: 0.6rem 1.75rem;
+    font-family: "Noto Serif TC", "Songti TC", "SimSun", serif;
+    font-size: 1.05em;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    color: var(--sgbs-paper);
+    background: var(--sgbs-vermilion);
+    border: 1px solid var(--sgbs-vermilion);
+    border-radius: 6px;
+    text-decoration: none;
+    transition: background 0.15s ease, color 0.15s ease,
+        border-color 0.15s ease;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.typography a.register-cta:hover,
+.typography a.register-cta:focus-visible {
+    color: var(--sgbs-vermilion);
+    background: transparent;
+    text-decoration: none;
+}
+
+.typography a.register-cta:focus-visible {
+    outline: 2px solid var(--sgbs-vermilion);
+    outline-offset: 2px;
+}
+
+/* A hair lighter than --sgbs-vermilion so paper-dark text keeps AA. */
+.dark .typography a.register-cta {
+    background: #d4603f;
+    border-color: #d4603f;
+}
+
+/*
+ * QR share card – a single card for handing the page to someone else.
+ * (Two QRs side by side read as "scan one of these," which made no
+ * sense on the page itself; registration now leads as a text CTA.)
  */
 .qrcode-options {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: 1.25rem;
     margin: 1.5rem 0;
+}
+
+/* Single share card sits centered instead of stretching the grid. */
+.qrcode-options--single {
+    grid-template-columns: 1fr;
+    max-width: 26rem;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .qrcode-option {


### PR DESCRIPTION
## Summary

The landing page's QR section was framed as 「依你的需要選一個掃描」 — but a QR to the page you are already on is purely a **transfer** tool, and for the person holding the device the plain link always beats the QR. Final design:

- **報名 leads**: right under the welcome, one centered card holds the registration QR — styled like the share card below. Clicking the QR goes straight to the registration site.
- **First-load tap hint**: on page load, a pointer icon (cursor on mouse devices, pointing finger on touch screens) slides in from the card corner and taps the QR a few times with a vermilion ripple, then fades. Pure CSS — three cycles, dismissed on hover/focus, hidden under `prefers-reduced-motion`. Verified frame-by-frame via headless screenshots.
- **分享這門課 at the bottom**: the website QR in a single centered card, explicitly framed as show-this-screen-to-someone-else, plus the plain URL as a fallback.
- **2026秋季 dates**: 9月20日開始，共五週 (Sundays 9/20–10/18), matching the roster app's `CURRENT_QUARTER_SESSION_DATES`.

The off-season 「已停止接受註冊」 commented switch is preserved for end-of-season use. `registration-qrcode.png` / `website-qrcode.png` both still in use.

## Verification

- markdownlint: clean (only the repo's documented MD033 raw-HTML exception)
- `pixi run -e website build`: passes
- Headless browser screenshots confirm the tap-hint icon renders correctly in both cursor and finger modes