### PR TITLE
fix(theme): alias legacy Material tokens so dark mode follows the scripture palette

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1478,6 +1478,17 @@ article.typography table tbody tr:hover,
   --input: var(--sgbs-rule);
   --ring: var(--sgbs-vermilion);
 
+  /* Legacy mkdocs-material token names still referenced by some older
+     components (role-card 職責/每週功課 labels, expandable-card headings,
+     homework cards). The vars are undefined in this theme, so their
+     light-only rgba(0,0,0,…)/#fff fallbacks were being used — invisible
+     on dark paper. Alias them to the scripture palette; since .dark
+     remaps the underlying --sgbs-* and --card tokens, these follow
+     light/dark with the rest of the system. */
+  --md-default-fg-color--light: var(--sgbs-ink-soft);
+  --md-default-fg-color--lightest: rgba(var(--sgbs-ink-rgb), 0.08);
+  --md-default-bg-color: var(--card);
+
   /* Serif typography: the scripture-page world is a printed sheet. */
   --font-sans: "Noto Serif TC", "Songti TC", "SimSun", ui-serif, Georgia,
     serif;


### PR DESCRIPTION
## ELI5

In dark mode, some small headings on the homepage role cards — 職責 and 每週功課 — were nearly invisible: dark-gray text on dark-brown cards (1.2:1 contrast). The homework cards on lesson pages were worse: they stayed **pure white** at night. This fixes all of them by teaching the design system the old variable names those components still use, instead of patching each element one by one.

## Root cause

When the site moved from mkdocs-material to the shadcn/scripture-page theme, the new theme stopped defining a few legacy Material token names. Components still referencing them via `var(--md-default-fg-color--light, <fallback>)` silently fell back to their light-only defaults:

| Consumer | Fallback used | Dark-mode result |
|---|---|---|
| `.role-card__label` (職責 / 每週功課) | `rgba(0,0,0,0.7)` | 1.20:1 contrast on #241e16 cards |
| `.expandable-card__body strong` | `rgba(0,0,0,0.7)` | invisible headings |
| `.homework-item` background | `#fff` | white cards at night |
| `.expandable-card` / `.homework-item` borders + number badges | `rgba(0,0,0,…)` | invisible rules/badges |

## Fix

Define the legacy names **once** in the scripture-theme `:root` token block as aliases of the existing palette:

```css
--md-default-fg-color--light: var(--sgbs-ink-soft);
--md-default-fg-color--lightest: rgba(var(--sgbs-ink-rgb), 0.08);
--md-default-bg-color: var(--card);
```

No per-element overrides. Because the `.dark` block already remaps `--sgbs-ink-soft` / `--sgbs-ink-rgb` / `--card`, every consumer — past and future — follows light/dark automatically.

## Verification (in-browser, real Chrome, localhost)

- Dark role-card labels: `rgb(168,158,136)` (= dark `--sgbs-ink-soft`) on `rgb(36,30,22)` → **6.22:1** (was 1.20:1); passes WCAG AA
- Light mode unchanged in spirit: `#57503f` on `#f0e9d8` → **6.61:1**
- Homework cards in dark: `#201a13` (`--card`) instead of `#fff`
- Body-text contrast untouched: 13.04:1
- Diff is +11 lines in one file, all inside the existing `:root` token block