### PR TITLE
feat(roster): send a welcome email when registration completes

### DIFF
--- a/apps/roster/convex/auth.ts
+++ b/apps/roster/convex/auth.ts
@@ -191,6 +191,13 @@ export const verifyRegistrationCode = mutation({
         missed: 0,
         photoStorageId: registration.photoStorageId,
       });
+      // Welcome email fires once, on the quarter's creating registration
+      // only. Scheduled (not awaited send): the mutation returns first,
+      // so SMTP trouble never blocks or fails the sign-up itself.
+      await ctx.scheduler.runAfter(0, internal.authEmail.sendWelcomeEmail, {
+        email: addr,
+        name,
+      });
     }
     return {
       status: duplicate ? ("duplicate" as const) : ("created" as const),

--- a/apps/roster/convex/authEmail.ts
+++ b/apps/roster/convex/authEmail.ts
@@ -17,27 +17,75 @@
 import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import nodemailer from "nodemailer";
+import {
+  CURRENT_QUARTER,
+  CURRENT_QUARTER_SESSION_DATES,
+} from "../src/constants";
+
+// Welcome-email class facts derive from the shared constants so a new
+// quarter cannot silently send stale dates. The clock time is not part
+// of the sessions data — update here if the announced time changes.
+const FIRST_CLASS_TIME = "下午3:00";
+
+const CN_MONTHS = [
+  "", "一", "二", "三", "四", "五", "六", "七", "八", "九", "十", "十一", "十二",
+];
+
+// "2026-09-20" → "9月20日（主日）" — Sunday renders as 主日, weekdays as 週一…
+function zhDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const wd = ["日", "一", "二", "三", "四", "五", "六"][
+    new Date(y, m - 1, d).getDay()
+  ];
+  return `${m}月${d}日（${wd === "日" ? "主日" : `週${wd}`}）`;
+}
+
+// "2026-09-20" → "9月20日" (no weekday label, for date ranges)
+function zhDatePlain(iso: string): string {
+  const [, m, d] = iso.split("-").map(Number);
+  return `${m}月${d}日`;
+}
+
+// "2026-09-20" → "9/20"
+function shortDate(iso: string): string {
+  const [, m, d] = iso.split("-").map(Number);
+  return `${m}/${d}`;
+}
+
+// "2026秋季" → "2026 秋季"
+function quarterLabel(q: string): string {
+  return `${q.slice(0, 4)} ${q.slice(4)}`;
+}
+
+// Shared SMTP plumbing — one transport builder, one sender line, used by
+// both the verification-code and welcome emails.
+function makeTransport() {
+  const { SMTP_USER, SMTP_PASS } = process.env;
+  if (!SMTP_USER || !SMTP_PASS) {
+    throw new Error("SMTP_USER / SMTP_PASS are not set on this deployment");
+  }
+  return nodemailer.createTransport({
+    host: process.env.SMTP_HOST ?? "smtp.gmail.com",
+    port: 465,
+    secure: true,
+    auth: { user: SMTP_USER, pass: SMTP_PASS },
+  });
+}
+
+function senderAddress() {
+  const { SMTP_USER, SMTP_FROM } = process.env;
+  return SMTP_FROM ?? `小組查經訓練 <${SMTP_USER}>`;
+}
 
 export const sendCodeEmail = internalAction({
   args: { email: v.string(), code: v.string(), name: v.optional(v.string()) },
   handler: async (_ctx, { email, code, name }) => {
-    const { SMTP_USER, SMTP_PASS, SMTP_FROM } = process.env;
-    if (!SMTP_USER || !SMTP_PASS) {
-      throw new Error("SMTP_USER / SMTP_PASS are not set on this deployment");
-    }
-    const from = SMTP_FROM ?? `小組查經訓練 <${SMTP_USER}>`;
     const greeting = name ? `${name}，平安！` : "平安！";
-
-    const transport = nodemailer.createTransport({
-      host: process.env.SMTP_HOST ?? "smtp.gmail.com",
-      port: 465,
-      secure: true,
-      auth: { user: SMTP_USER, pass: SMTP_PASS },
-    });
+    const transport = makeTransport();
 
     try {
       await transport.sendMail({
-        from,
+        from: senderAddress(),
         to: email,
         subject: `小組查經訓練報名驗證碼：${code}`,
         text: [
@@ -65,5 +113,73 @@ export const sendCodeEmail = internalAction({
         `發送驗證碼失敗：請稍後再試或聯絡同工。${detail.slice(0, 140)}`,
       );
     }
+  },
+});
+
+// Welcome email: sent once, when a student row is first created for the
+// current quarter (scheduled from auth.verifyRegistrationCode on the
+// "created" path only — duplicates and returning members re-verifying
+// stay silent). Brief by design: confirm the registration, name the
+// first class, point at the course site.
+export const sendWelcomeEmail = internalAction({
+  args: { email: v.string(), name: v.optional(v.string()) },
+  handler: async (_ctx, { email, name }) => {
+    const greeting = name ? `${name}，平安！` : "平安！";
+    const dates = CURRENT_QUARTER_SESSION_DATES;
+    const first = dates[0];
+    const last = dates[dates.length - 1];
+    const firstMonth = CN_MONTHS[Number(first.split("-")[1])];
+    const quarter = quarterLabel(CURRENT_QUARTER);
+
+    const subject = `歡迎報名小組查經訓練主日學（${shortDate(first)} 開課）`;
+    const text = [
+      greeting,
+      "",
+      `您的報名已收到——歡迎加入 ${quarter}小組查經訓練主日學！`,
+      "",
+      `第一堂課：${zhDate(first)}${FIRST_CLASS_TIME}`,
+      "地點：CBCGB 城光堂三樓",
+      "",
+      `課程共${dates.length}週，每週主日（${zhDatePlain(first)}至${zhDatePlain(last)}）。` +
+        "若您希望取得完成記錄，請至少出席四堂。",
+      "課程資訊與講義：https://cbcgb-com.github.io/sgbs-training/",
+      "",
+      `期待${firstMonth}月在課堂相見！若有任何問題，歡迎聯絡同工。`,
+      "",
+      "小組查經訓練主日學 · CBCGB",
+    ].join("\n");
+    const html = [
+      `<p style="font-size:15px">${greeting}</p>`,
+      `<p style="font-size:15px">您的報名已收到——歡迎加入 <b>${quarter}小組查經訓練主日學</b>！</p>`,
+      `<p style="font-size:15px">第一堂課：<span style="color:#b3402a;font-weight:bold">${zhDate(first)}${FIRST_CLASS_TIME}</span><br>地點：CBCGB 城光堂三樓</p>`,
+      `<p style="font-size:13px;color:#555">課程共${dates.length}週，每週主日（${zhDatePlain(first)}至${zhDatePlain(last)}）。若您希望取得完成記錄，請至少出席四堂。</p>`,
+      `<p style="font-size:13px;color:#555">課程資訊與講義：<a href="https://cbcgb-com.github.io/sgbs-training/">https://cbcgb-com.github.io/sgbs-training/</a></p>`,
+      `<p style="font-size:13px;color:#555">期待${firstMonth}月在課堂相見！若有任何問題，歡迎聯絡同工。</p>`,
+      `<p style="font-size:13px;color:#555">小組查經訓練主日學 · CBCGB</p>`,
+    ].join("");
+
+    const transport = makeTransport();
+    // Convex runs scheduled actions AT MOST ONCE — no automatic retry —
+    // so a transient SMTP blip would silently drop the note. Retry a
+    // little here. Registration itself is unaffected either way: the
+    // student row is already committed when this action runs.
+    let lastErr: unknown;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        await transport.sendMail({
+          from: senderAddress(),
+          to: email,
+          subject,
+          text,
+          html,
+        });
+        return;
+      } catch (err) {
+        lastErr = err;
+        if (attempt < 3) await new Promise((r) => setTimeout(r, 2000));
+      }
+    }
+    const detail = lastErr instanceof Error ? lastErr.message : String(lastErr);
+    throw new Error(`發送歡迎郵件失敗（不影響報名）：${detail.slice(0, 140)}`);
   },
 });

--- a/apps/roster/convex/students.ts
+++ b/apps/roster/convex/students.ts
@@ -1,5 +1,6 @@
 import { internalMutation, mutation, query } from "./_generated/server";
 import { v } from "convex/values";
+import { internal } from "./_generated/api";
 import type { Doc, Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { CURRENT_QUARTER } from "../src/constants";
@@ -472,6 +473,15 @@ export const registerStudent = mutation({
       // Attendance starts unrecorded (0 misses recorded), not 5.
       missed: 0,
       photoStorageId: args.photoStorageId,
+    });
+    // Welcome email for in-person signups too (2026-09-06 decision):
+    // the instructor vouches for the address, so no code email
+    // preceded this — the welcome note IS their first contact.
+    // Scheduled, not awaited: the instructor's save never blocks or
+    // fails on SMTP trouble.
+    await ctx.scheduler.runAfter(0, internal.authEmail.sendWelcomeEmail, {
+      email: targetEmail,
+      name: targetName,
     });
     return { status: "created" as const, id };
   },

--- a/apps/roster/docs/designs/authentication/LLD.md
+++ b/apps/roster/docs/designs/authentication/LLD.md
@@ -185,6 +185,24 @@ in the default V8 runtime:
 - Delivery target: whatever address the member typed. Failures return
   a friendly error; retry is free (regenerate the code).
 
+### Welcome email
+
+A second action in the same file (`authEmail.sendWelcomeEmail`) sends a
+brief welcome note — registration confirmation, the first class date
+(derived from `CURRENT_QUARTER_SESSION_DATES`, so a new quarter cannot
+send stale dates), the 4-of-5 attendance rule, and a link to the
+course site. It is scheduled from `auth.verifyRegistrationCode` on the
+**created** path only: duplicate registrations and returning members
+re-verifying for the quarter stay silent. `students.registerStudent`
+(instructor-managed signups) schedules the same action on its created
+path. Because it is a scheduled
+action (not an awaited send), the registration mutation returns first
+— SMTP trouble never blocks or fails the sign-up. Convex runs
+scheduled actions at most once (no automatic retry), so the action
+performs its own small retry (3 attempts) around transient SMTP
+failures; a permanent failure surfaces as a failed job in the Convex
+dashboard and the member can simply be emailed manually.
+
 ### Deliverability (verified 2026-09-04 via DNS + Resend API)
 
 - cbcgb.org DNS is hosted at easyDNS (`dns1.easydns.com` etc.) —
@@ -226,15 +244,21 @@ in the default V8 runtime:
   `authEmail.sendCodeEmail` node action.
 - `authEmail.sendCodeEmail` (internal action, `convex/authEmail.ts`) —
   Gmail SMTP send via nodemailer.
-- `auth.verifyCode` (mutation) — consume the code, insert/update the
-  student row (self-registration path), create a session, return the
-  JWT + its expiry.
-- `auth.signIn` (mutation) — email lookup per the Sign-in flow; create
-  session, return JWT. Uniform failure for unknown emails (no user
-  enumeration).
+- `auth.verifyRegistrationCode` (mutation) — consume the code, create
+  the student row (self-registration path), schedule
+  `authEmail.sendWelcomeEmail` on the created path, return the code's
+  issuedAt for the follow-up sign-in.
+- `auth.completeRegistrationSignIn` (action) — verify a consumed code
+  exists for the email, issue the session JWT.
+- `auth.signIn` (action) — email lookup per the Sign-in flow; issue
+  JWT. Uniform failure for unknown emails (no user enumeration).
 - `auth.signOut` (mutation) — mark the session revoked.
-- `students.registerInstructorManaged` — as before (admin mode), now
-  creating the same authCodes row for the registrant's email.
+- `students.registerStudent` — instructor-managed registration
+  (admin mode): the instructor vouches for the address; the student
+  row is created directly, no authCodes row involved. Also schedules
+  the welcome email on the created path (2026-09-06 decision —
+  in-person signups get the same first-class-details note; no code
+  email precedes it, so the welcome note is their first contact).
 
 Legacy helpers unchanged; `clerkId` references removed.
 


### PR DESCRIPTION
## What

After a member completes registration, the roster now sends a brief welcome email: registration confirmation, the first class (9/20 主日 下午3:00, CBCGB 城光堂三樓), the 4-of-5 attendance rule, and a link to the course notes site.

## Where it fires

- **Self-registration** — `auth.verifyRegistrationCode` schedules `authEmail.sendWelcomeEmail` on the created path only (code verified → row committed → email scheduled; the session sign-in follows a beat later in the same click). Duplicates and returning members re-verifying stay silent.
- **Instructor-managed signups** — `students.registerStudent` schedules the same note; for in-person signups this is their first contact since no verification code precedes the row.

## Details

- Scheduled action (not awaited): registration/instructor-save never blocks or fails on SMTP trouble.
- Convex runs scheduled actions at most once, so the action retries transient SMTP failures itself (3 attempts).
- Email dates derive from `CURRENT_QUARTER_SESSION_DATES` / `CURRENT_QUARTER` — bumping the quarter constants updates the email automatically. The clock time (下午3:00) is a named constant in `authEmail.ts`.
- Same Gmail SMTP path as the verification-code email (shared transport helpers); same sender (`小組查經訓練 <no-reply-com@cbcgb.org>`).

## Docs

Auth LLD updated: new Welcome email section, plus corrections to the stale Functions list (`verifyCode` → `verifyRegistrationCode` + `completeRegistrationSignIn`; `signIn` is an action; `registerStudent` replaces the nonexistent `registerInstructorManaged`).

## Follow-up (not in this PR)

One-off backfill: send the welcome note to members who registered before this ships.